### PR TITLE
Added directory creation to install-driver.sh in order to fix daemon…

### DIFF
--- a/deploy/binary-build-and-deploy-scripts/install-driver.sh
+++ b/deploy/binary-build-and-deploy-scripts/install-driver.sh
@@ -33,11 +33,11 @@ cat /root/.ssh/id_rsa.pub >> /host/root/.ssh/authorized_keys
 chmod 700 /host/root/.ssh/
 chmod 600 /host/root/.ssh/authorized_keys
 
+touch /host/etc/ssh/sshd_config
 sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /host/etc/ssh/sshd_config
 /root/bin/systemutil -service ssh.service
 
 ssh -o StrictHostKeyChecking=no root@localhost bash /root/install-dep.sh
-
 
 sed -i 's/PermitRootLogin yes/PermitRootLogin no/g' /host/etc/ssh/sshd_config
 /root/bin/systemutil -service ssh.service

--- a/deploy/binary-build-and-deploy-scripts/install-driver.sh
+++ b/deploy/binary-build-and-deploy-scripts/install-driver.sh
@@ -4,6 +4,7 @@ set -ex
 DRIVER_LOCATION="/host/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ibmc-s3fs"
 KUBELET_SVC_CONFIG="/host/lib/systemd/system/kubelet.service"
 
+mkdir -p /host/local/bin
 cp /root/bin/s3fs /host/local/bin/
 cp /root/bin/install-dep.sh /host/root/
 chmod +x /host/local/bin/s3fs /host/root/install-dep.sh 


### PR DESCRIPTION
…set deployment.

I apologize for missing a line in my previous PR - I had already fixed this issue before, but apparently didn't commit it properly. A colleague of mine has successfully deployed FfDL with this change, so this PR is already partially reviewed (besides it working for me, of course).

Side note: We do have an old cluster that does not even have the `/host/etc/ssh/` subdirectory and will thus fail around line 36 (also on original code). I'll look into why that is, but current Kubernetes clusters should have it and it is possible that this is due to manual modifications - the cluster was definitely modified by developers. Shouldn't affect this PR, but might turn into another PR, i.e. fallback code to handle this directory not being present.