### PR TITLE
Fixed path for s3fs to be /usr/local/bin rather than /local/bin.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+deploy/binary-build-and-deploy-scripts/bin/
+deploy/binary-build-and-deploy-scripts/ibmcloud-object-storage-plugin/
+deploy/binary-build-and-deploy-scripts/s3fs-fuse/

--- a/deploy/binary-build-and-deploy-scripts/install-driver.sh
+++ b/deploy/binary-build-and-deploy-scripts/install-driver.sh
@@ -4,8 +4,7 @@ set -ex
 DRIVER_LOCATION="/host/usr/libexec/kubernetes/kubelet-plugins/volume/exec/ibm~ibmc-s3fs"
 KUBELET_SVC_CONFIG="/host/lib/systemd/system/kubelet.service"
 
-mkdir -p /host/local/bin
-cp /root/bin/s3fs /host/local/bin/
+cp /root/bin/s3fs /host/usr/local/bin/
 cp /root/bin/install-dep.sh /host/root/
 chmod +x /host/local/bin/s3fs /host/root/install-dep.sh 
 

--- a/deploy/binary-build-and-deploy-scripts/install-driver.sh
+++ b/deploy/binary-build-and-deploy-scripts/install-driver.sh
@@ -6,7 +6,7 @@ KUBELET_SVC_CONFIG="/host/lib/systemd/system/kubelet.service"
 
 cp /root/bin/s3fs /host/usr/local/bin/
 cp /root/bin/install-dep.sh /host/root/
-chmod +x /host/local/bin/s3fs /host/root/install-dep.sh 
+chmod +x /host/usr/local/bin/s3fs /host/root/install-dep.sh 
 
 if [ -e "$DRIVER_LOCATION/ibmc-s3fs" ]
 then


### PR DESCRIPTION
Fixed the s3fs target path as discussed earlier. Verified by me and Tommy C. Li.
Also added the directories that `build-all.sh` creates to `.gitignore`.