### PR TITLE
Add support for setting 'stat_cache_expire' through PVC annotation

### DIFF
--- a/deploy/sample-usage/pod-vol.yaml
+++ b/deploy/sample-usage/pod-vol.yaml
@@ -23,6 +23,7 @@ spec:
         parallel-count: "24"
         multireq-max: "30"
         stat-cache-size: "100000"
+        stat-cache-expire-seconds: ""   # stat-cache-expire time in seconds; default is no expire.
         s3fs-fuse-retry-count: "5"
         debug-level: "warn"
         curl-debug: "false"

--- a/deploy/sample-usage/pvc.yaml
+++ b/deploy/sample-usage/pvc.yaml
@@ -10,6 +10,7 @@ metadata:
     ibm.io/endpoint: "https://s3-api.dal-us-geo.objectstorage.service.networklayer.com"
     ibm.io/region: "us-standard"
     ibm.io/secret-name: "test-secret"
+    ibm.io/stat-cache-expire-seconds: ""   # stat-cache-expire time in seconds; default is no expire.
 spec:
   accessModes:
     - ReadWriteOnce

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -280,13 +280,17 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 
 	//Check if value of stat-cache-expire-seconds parameter can be converted to integer
 	if options.StatCacheExpireSeconds != "" {
-		_, err := strconv.Atoi(options.StatCacheExpireSeconds)
+		cacheExpireSeconds, err := strconv.Atoi(options.StatCacheExpireSeconds)
 		if err != nil {
 			p.Logger.Error(hostname+" Component: S3FS Driver, "+
 				"Message: Cannot convert value of stat-cache-expire-seconds into integer",
 				zap.Error(err))
 			return fmt.Errorf("Cannot convert value of stat-cache-expire-seconds into integer: %v", err)
-		}
+		} else if cacheExpireSeconds < 0 {
+			p.Logger.Error(hostname+" Component: S3FS Driver, "+
+				"Message: value of stat-cache-expire-seconds should be >= 0",
+				zap.Error(err))
+			return fmt.Errorf("Message: value of stat-cache-expire-seconds should be >= 0")
 	}
 
 	if options.APIKeyB64 != "" {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -291,6 +291,7 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 				"Message: value of stat-cache-expire-seconds should be >= 0",
 				zap.Error(err))
 			return fmt.Errorf("Message: value of stat-cache-expire-seconds should be >= 0")
+		}
 	}
 
 	if options.APIKeyB64 != "" {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -58,22 +58,23 @@ var buildVersion string
 
 // Options are the FlexVolume driver options
 type Options struct {
-	ChunkSizeMB        int    `json:"chunk-size-mb,string"`
-	ParallelCount      int    `json:"parallel-count,string"`
-	MultiReqMax        int    `json:"multireq-max,string"`
-	StatCacheSize      int    `json:"stat-cache-size,string"`
-	FSGroup            string `json:"kubernetes.io/fsGroup,omitempty"`
-	Endpoint           string `json:"endpoint"`
-	Region             string `json:"region"`
-	Bucket             string `json:"bucket"`
-	DebugLevel         string `json:"debug-level"`
-	CurlDebug          bool   `json:"curl-debug,string"`
-	KernelCache        bool   `json:"kernel-cache,string,omitempty"`
-	TLSCipherSuite     string `json:"tls-cipher-suite,omitempty"`
-	S3FSFUSERetryCount string `json:"s3fs-fuse-retry-count,omitempty"`
-	AccessKeyB64       string `json:"kubernetes.io/secret/access-key,omitempty"`
-	SecretKeyB64       string `json:"kubernetes.io/secret/secret-key,omitempty"`
-	APIKeyB64          string `json:"kubernetes.io/secret/api-key,omitempty"`
+	ChunkSizeMB            int    `json:"chunk-size-mb,string"`
+	ParallelCount          int    `json:"parallel-count,string"`
+	MultiReqMax            int    `json:"multireq-max,string"`
+	StatCacheSize          int    `json:"stat-cache-size,string"`
+	FSGroup                string `json:"kubernetes.io/fsGroup,omitempty"`
+	Endpoint               string `json:"endpoint"`
+	Region                 string `json:"region"`
+	Bucket                 string `json:"bucket"`
+	DebugLevel             string `json:"debug-level"`
+	CurlDebug              bool   `json:"curl-debug,string"`
+	KernelCache            bool   `json:"kernel-cache,string,omitempty"`
+	TLSCipherSuite         string `json:"tls-cipher-suite,omitempty"`
+	S3FSFUSERetryCount     string `json:"s3fs-fuse-retry-count,omitempty"`
+	StatCacheExpireSeconds string `json:"stat-cache-expire-seconds,omitempty"`
+	AccessKeyB64           string `json:"kubernetes.io/secret/access-key,omitempty"`
+	SecretKeyB64           string `json:"kubernetes.io/secret/secret-key,omitempty"`
+	APIKeyB64              string `json:"kubernetes.io/secret/api-key,omitempty"`
 }
 
 // S3fsPlugin supports mount & unmount requests of s3fs volumes
@@ -277,6 +278,17 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 		}
 	}
 
+	//Check if value of stat-cache-expire-seconds parameter can be converted to integer
+	if options.StatCacheExpireSeconds != "" {
+		_, err := strconv.Atoi(options.StatCacheExpireSeconds)
+		if err != nil {
+			p.Logger.Error(hostname+" Component: S3FS Driver, "+
+				"Message: Cannot convert value of stat-cache-expire-seconds into integer",
+				zap.Error(err))
+			return fmt.Errorf("Cannot convert value of stat-cache-expire-seconds into integer: %v", err)
+		}
+	}
+
 	if options.APIKeyB64 != "" {
 		apiKey, err = parser.DecodeBase64(options.APIKeyB64)
 		if err != nil {
@@ -380,6 +392,10 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 	//Number of retries for failed S3 transaction
 	if options.S3FSFUSERetryCount != "" {
 		args = append(args, "-o", "retries="+options.S3FSFUSERetryCount)
+	}
+
+	if options.StatCacheExpireSeconds != "" {
+		args = append(args, "-o", "stat_cache_expire="+options.StatCacheExpireSeconds)
 	}
 
 	if options.CurlDebug {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -223,7 +223,7 @@ func Test_Mount_S3FSFUSERetryCount_Zero(t *testing.T) {
 	}
 }
 
-func Test_Mount_BadStatCacheExpireSeconds(t *testing.T) {
+func Test_Mount_BadStatCacheExpireSeconds_NonInt(t *testing.T) {
 	p := getPlugin()
 	r := getMountRequest()
 	r.Opts[optionStatCacheExpireSeconds] = "non-int-value"
@@ -231,6 +231,17 @@ func Test_Mount_BadStatCacheExpireSeconds(t *testing.T) {
 	resp := p.Mount(r)
 	if assert.Equal(t, interfaces.StatusFailure, resp.Status) {
 		assert.Contains(t, resp.Message, "Cannot convert value of stat-cache-expire-seconds into integer")
+	}
+}
+
+func Test_Mount_BadStatCacheExpireSeconds_NegativeInt(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionStatCacheExpireSeconds] = "-10"
+
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusFailure, resp.Status) {
+		assert.Contains(t, resp.Message, "value of stat-cache-expire-seconds should be >= 0")
 	}
 }
 

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -184,11 +184,11 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	//Check if value of stat-cache-expire-seconds parameter can be converted to integer
 	if pvc.StatCacheExpireSeconds != "" {
-		 cacheExpireSeconds, err := strconv.Atoi(pvc.StatCacheExpireSeconds)
-		 if err != nil {
+		cacheExpireSeconds, err := strconv.Atoi(pvc.StatCacheExpireSeconds)
+		if err != nil {
 			return nil, fmt.Errorf(pvcName+":Cannot convert value of stat-cache-expire-seconds into integer: %v", err)
 		} else if cacheExpireSeconds < 0 {
-			return nil, fmt.Errorf(pvcName+":value of stat-cache-expire-seconds should be >= 0")
+			return nil, fmt.Errorf(pvcName + ":value of stat-cache-expire-seconds should be >= 0")
 		}
 	}
 

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -29,17 +29,18 @@ import (
 
 // PVC annotations
 type pvcAnnotations struct {
-	AutoCreateBucket   bool   `json:"ibm.io/auto-create-bucket,string"`
-	AutoDeleteBucket   bool   `json:"ibm.io/auto-delete-bucket,string"`
-	Bucket             string `json:"ibm.io/bucket"`
-	Endpoint           string `json:"ibm.io/endpoint"`
-	Region             string `json:"ibm.io/region"`
-	SecretName         string `json:"ibm.io/secret-name"`
-	ChunkSizeMB        string `json:"ibm.io/chunk-size-mb,omitempty"`
-	ParallelCount      string `json:"ibm.io/parallel-count,omitempty"`
-	MultiReqMax        string `json:"ibm.io/multireq-max,omitempty"`
-	StatCacheSize      string `json:"ibm.io/stat-cache-size,omitempty"`
-	S3FSFUSERetryCount string `json:"ibm.io/s3fs-fuse-retry-count,omitempty"`
+	AutoCreateBucket       bool   `json:"ibm.io/auto-create-bucket,string"`
+	AutoDeleteBucket       bool   `json:"ibm.io/auto-delete-bucket,string"`
+	Bucket                 string `json:"ibm.io/bucket"`
+	Endpoint               string `json:"ibm.io/endpoint"`
+	Region                 string `json:"ibm.io/region"`
+	SecretName             string `json:"ibm.io/secret-name"`
+	ChunkSizeMB            string `json:"ibm.io/chunk-size-mb,omitempty"`
+	ParallelCount          string `json:"ibm.io/parallel-count,omitempty"`
+	MultiReqMax            string `json:"ibm.io/multireq-max,omitempty"`
+	StatCacheSize          string `json:"ibm.io/stat-cache-size,omitempty"`
+	S3FSFUSERetryCount     string `json:"ibm.io/s3fs-fuse-retry-count,omitempty"`
+	StatCacheExpireSeconds string `json:"ibm.io/stat-cache-expire-seconds,omitempty"`
 }
 
 // PV annotations
@@ -181,6 +182,13 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		}
 	}
 
+	//Check if value of stat-cache-expire-seconds parameter can be converted to integer
+	if pvc.StatCacheExpireSeconds != "" {
+		if _, err := strconv.Atoi(pvc.StatCacheExpireSeconds); err != nil {
+			return nil, fmt.Errorf(pvcName+":Cannot convert value of stat-cache-expire-seconds into integer: %v", err)
+		}
+	}
+
 	if pvc.AutoDeleteBucket {
 		if !pvc.AutoCreateBucket {
 			return nil, errors.New(pvcName + ":bucket auto-create must be enabled when bucket auto-delete is enabled")
@@ -224,18 +232,19 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	}
 
 	driverOptions, err := parser.MarshalToMap(&driver.Options{
-		ChunkSizeMB:        sc.ChunkSizeMB,
-		ParallelCount:      sc.ParallelCount,
-		MultiReqMax:        sc.MultiReqMax,
-		StatCacheSize:      sc.StatCacheSize,
-		TLSCipherSuite:     sc.TLSCipherSuite,
-		CurlDebug:          sc.CurlDebug,
-		KernelCache:        sc.KernelCache,
-		DebugLevel:         sc.DebugLevel,
-		S3FSFUSERetryCount: strconv.Itoa(sc.S3FSFUSERetryCount),
-		Endpoint:           pvc.Endpoint,
-		Region:             pvc.Region,
-		Bucket:             pvc.Bucket,
+		ChunkSizeMB:            sc.ChunkSizeMB,
+		ParallelCount:          sc.ParallelCount,
+		MultiReqMax:            sc.MultiReqMax,
+		StatCacheSize:          sc.StatCacheSize,
+		TLSCipherSuite:         sc.TLSCipherSuite,
+		CurlDebug:              sc.CurlDebug,
+		KernelCache:            sc.KernelCache,
+		DebugLevel:             sc.DebugLevel,
+		S3FSFUSERetryCount:     strconv.Itoa(sc.S3FSFUSERetryCount),
+		StatCacheExpireSeconds: pvc.StatCacheExpireSeconds,
+		Endpoint:               pvc.Endpoint,
+		Region:                 pvc.Region,
+		Bucket:                 pvc.Bucket,
 	})
 	if err != nil {
 		return nil, fmt.Errorf(pvcName+":cannot marshal driver options: %v", err)

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -184,8 +184,11 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	//Check if value of stat-cache-expire-seconds parameter can be converted to integer
 	if pvc.StatCacheExpireSeconds != "" {
-		if _, err := strconv.Atoi(pvc.StatCacheExpireSeconds); err != nil {
+		 cacheExpireSeconds, err := strconv.Atoi(pvc.StatCacheExpireSeconds)
+		 if err != nil {
 			return nil, fmt.Errorf(pvcName+":Cannot convert value of stat-cache-expire-seconds into integer: %v", err)
+		} else if cacheExpireSeconds < 0 {
+			return nil, fmt.Errorf(pvcName+":value of stat-cache-expire-seconds should be >= 0")
 		}
 	}
 

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -48,13 +48,14 @@ const (
 	testCurlDebug          = "false"
 	testTLSCipherSuite     = "test-tls-cipher-suite"
 
-	annotationBucket           = "ibm.io/bucket"
-	annotationAutoCreateBucket = "ibm.io/auto-create-bucket"
-	annotationAutoDeleteBucket = "ibm.io/auto-delete-bucket"
-	annotationEndpoint         = "ibm.io/endpoint"
-	annotationRegion           = "ibm.io/region"
-	annotationSecretName       = "ibm.io/secret-name"
-	annotationSecretNamespace  = "ibm.io/secret-namespace"
+	annotationBucket                 = "ibm.io/bucket"
+	annotationAutoCreateBucket       = "ibm.io/auto-create-bucket"
+	annotationAutoDeleteBucket       = "ibm.io/auto-delete-bucket"
+	annotationEndpoint               = "ibm.io/endpoint"
+	annotationRegion                 = "ibm.io/region"
+	annotationSecretName             = "ibm.io/secret-name"
+	annotationSecretNamespace        = "ibm.io/secret-namespace"
+	annotationStatCacheExpireSeconds = "ibm.io/stat-cache-expire-seconds"
 
 	parameterChunkSizeMB        = "ibm.io/chunk-size-mb"
 	parameterParallelCount      = "ibm.io/parallel-count"
@@ -66,18 +67,19 @@ const (
 	parameterCurlDebug          = "ibm.io/curl-debug"
 	parameterKernelCache        = "ibm.io/kernel-cache"
 
-	optionChunkSizeMB        = "chunk-size-mb"
-	optionParallelCount      = "parallel-count"
-	optionMultiReqMax        = "multireq-max"
-	optionStatCacheSize      = "stat-cache-size"
-	optionS3FSFUSERetryCount = "s3fs-fuse-retry-count"
-	optionTLSCipherSuite     = "tls-cipher-suite"
-	optionDebugLevel         = "debug-level"
-	optionCurlDebug          = "curl-debug"
-	optionKernelCache        = "kernel-cache"
-	optionEndpoint           = "endpoint"
-	optionRegion             = "region"
-	optionBucket             = "bucket"
+	optionChunkSizeMB            = "chunk-size-mb"
+	optionParallelCount          = "parallel-count"
+	optionMultiReqMax            = "multireq-max"
+	optionStatCacheSize          = "stat-cache-size"
+	optionS3FSFUSERetryCount     = "s3fs-fuse-retry-count"
+	optionTLSCipherSuite         = "tls-cipher-suite"
+	optionDebugLevel             = "debug-level"
+	optionCurlDebug              = "curl-debug"
+	optionKernelCache            = "kernel-cache"
+	optionEndpoint               = "endpoint"
+	optionRegion                 = "region"
+	optionBucket                 = "bucket"
+	optionStatCacheExpireSeconds = "stat-cache-expire-seconds"
 )
 
 type clientGoConfig struct {
@@ -316,6 +318,27 @@ func Test_Provision_PVCAnnotations_StatCacheSize_Positive(t *testing.T) {
 	pv, err := p.Provision(v)
 	assert.NoError(t, err)
 	assert.Equal(t, "50", pv.Spec.FlexVolume.Options[optionStatCacheSize])
+}
+
+func Test_Provision_PVCAnnotations_BadStatCacheExpireSeconds(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationStatCacheExpireSeconds] = "non-int-value"
+
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Cannot convert value of stat-cache-expire-seconds into integer")
+	}
+}
+
+func Test_Provision_PVCAnnotations_StatCacheExpireSeconds_Positive(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationStatCacheExpireSeconds] = "6"
+
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "6", pv.Spec.FlexVolume.Options[optionStatCacheExpireSeconds])
 }
 
 func Test_Provision_PVCAnnotations_BadS3FSFUSERetryCount(t *testing.T) {

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -320,7 +320,7 @@ func Test_Provision_PVCAnnotations_StatCacheSize_Positive(t *testing.T) {
 	assert.Equal(t, "50", pv.Spec.FlexVolume.Options[optionStatCacheSize])
 }
 
-func Test_Provision_PVCAnnotations_BadStatCacheExpireSeconds(t *testing.T) {
+func Test_Provision_PVCAnnotations_BadStatCacheExpireSeconds_NonInt(t *testing.T) {
 	p := getProvisioner()
 	v := getVolumeOptions()
 	v.PVC.Annotations[annotationStatCacheExpireSeconds] = "non-int-value"
@@ -328,6 +328,17 @@ func Test_Provision_PVCAnnotations_BadStatCacheExpireSeconds(t *testing.T) {
 	_, err := p.Provision(v)
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "Cannot convert value of stat-cache-expire-seconds into integer")
+	}
+}
+
+func Test_Provision_PVCAnnotations_BadStatCacheExpireSeconds_NegativeInt(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationStatCacheExpireSeconds] = "-6"
+
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "value of stat-cache-expire-seconds should be >= 0")
 	}
 }
 


### PR DESCRIPTION
What this PR does / why we need it:
This PR allows to set **stat_cache_expire** time through PVC annotation.
```
stat_cache_expire: specify expire time(seconds) for entries in the stat cache. This expire time indicates the time since stat cached.
```

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
#(, fixes #12 )

Special notes for your reviewer:
Tested with K8S cluster deployed in IBM Cloud Kubernetes Service