### PR TITLE
Upgrade glide dependencies, go lang version and disable LeaderElection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - "1.10.7"
   - tip
 
 group: bluezone

--- a/cmd/provisioner/main.go
+++ b/cmd/provisioner/main.go
@@ -129,13 +129,14 @@ func main() {
 		*provisioner,
 		s3fsProvisioner,
 		serverVersion.GitVersion,
+		controller.LeaderElection(false),
 		controller.ResyncPeriod(resyncPeriod),
 		controller.ExponentialBackOffOnError(true),
 		controller.FailedProvisionThreshold(failedRetryThreshold),
 		controller.LeaseDuration(*leaseDuration),
 		controller.RenewDeadline(*leaseRenewDeadline),
 		controller.RetryPeriod(*leaseRetryPeriod),
-		controller.TermLimit(*leaseTermLimit),
+		//controller.TermLimit(*leaseTermLimit),
 	)
 
 	stopCh := make(chan struct{})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e4eddd94693d93ade7468ffe97acd5da48fecc23cc4e17294d5f79efea10d093
-updated: 2018-04-24T16:28:17.500186523Z
+hash: 9665b7a014c723da4fe358c69f24c39806efcd6d1ded62f9b4e51adcbe19cdbb
+updated: 2018-12-19T10:24:26.693416123-08:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: b90ee7ac719c7dec882a13e4c18c59bc1798ddfe
@@ -32,43 +32,46 @@ imports:
   - private/protocol/xml/xmlutil
   - service/s3
   - service/sts
-  - session
+- name: github.com/beorn7/perks
+  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  subpackages:
+  - quantile
 - name: github.com/BurntSushi/toml
-  version: a368813c5e648fee92e5f6c30e3944ff9d5e8895
+  version: 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005
+- name: github.com/campoy/embedmd
+  version: 97c13d6e41602fc6e397eb51c45f38069371a969
+  subpackages:
+  - embedmd
+- name: github.com/client9/misspell
+  version: 9ce5d979ffdaca6385988d7ad1079a33ec942d20
+  subpackages:
+  - cmd/misspell
 - name: github.com/coreos/go-systemd
-  version: d1b7d058aa2adfc795ad17ff4aaa2bc64ec11c78
+  version: 9002847aa1425fb6ac49077c0a630b3b67e0fbfd
   subpackages:
   - dbus
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
   - spew
-- name: github.com/emicklei/go-restful
-  version: ff4f55a206334ef123e4f79bbf348980da81ca46
-  subpackages:
-  - log
+- name: github.com/dustin/go-broadcast
+  version: f664265f5a662fb4d1df7f3533b1e8d0e0277120
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/gin-contrib/sse
   version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
+- name: github.com/gin-gonic/autotls
+  version: be87bd5ef97b7398e468c35ad266aabf099a095b
 - name: github.com/gin-gonic/gin
-  version: 814ac9490a38bb955a742d8ea15fa140489ee658
+  version: 1542eff27f7d67ef56543358e2f623eb4ea8adf9
   subpackages:
   - binding
-  - json
+  - internal/json
   - render
 - name: github.com/go-ini/ini
-  version: bda519ae5f4cbc60d391ff8610711627a08b86ae
-- name: github.com/go-openapi/jsonpointer
-  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
-- name: github.com/go-openapi/jsonreference
-  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
-- name: github.com/go-openapi/spec
-  version: 7abd5745472fff5eb3685386d5fb8bf38683154d
-- name: github.com/go-openapi/swag
-  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
+  version: 300e940a926eb277d3901b20bdfcc54928ad3642
 - name: github.com/godbus/dbus
-  version: d41f4c66e71d091df57cfee7bf5978c0d612a174
+  version: e25f905dbfbcdbc1fe19a684d9fe2a1261383ef8
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -81,7 +84,7 @@ imports:
   subpackages:
   - lru
 - name: github.com/golang/protobuf
-  version: 1643683e1b54a9e88ad26d98f81400c8c9d9f4f9
+  version: b4deda0973fb4c70b50d226b1af49f3da59f5265
   subpackages:
   - proto
   - ptypes
@@ -106,50 +109,73 @@ imports:
   version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
   subpackages:
   - simplelru
-- name: github.com/howeyc/gopass
-  version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
-  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
+  version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
+- name: github.com/jessevdk/go-assets
+  version: 4f4301a06e153ff90e17793577ab6bf79f8dc5c5
 - name: github.com/jessevdk/go-flags
-  version: 1c38ed7ad0cc3d9e66649ac398c30e45f395c4eb
+  version: c6ca198ec95c841fdb89fc0de7496fed11ab854e
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/json-iterator/go
-  version: 36b14963da70d11297d313183d7e6388c8510e1e
-- name: github.com/juju/ratelimit
-  version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
+  version: f2b4162afba35581b6d4a50d3b8f34e33c144682
 - name: github.com/kubernetes-incubator/external-storage
-  version: 7e0dccd17dd6e830508d0c5f563d853793e0c0d6
+  version: 193fb3944bf3061e59ae072ab7511861e8868553
   subpackages:
   - lib/controller
-  - lib/leaderelection
-  - lib/leaderelection/resourcelock
-- name: github.com/mailru/easyjson
-  version: 2f5df55504ebc322e4d52d34df6a1f5b503bf26d
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
+  - lib/controller/metrics
+  - lib/util
+- name: github.com/manucorporat/stats
+  version: 3ba42d56d227cf2a6086b63baba5e00669235853
 - name: github.com/mattn/go-isatty
-  version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
+  version: 3fb116b820352b7f0c281308a4d6250c22d94e27
+- name: github.com/matttproud/golang_protobuf_extensions
+  version: c12348ce28de40eed0136aa2b644d0ee0650e56c
+  subpackages:
+  - pbutil
+- name: github.com/modern-go/concurrent
+  version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
+- name: github.com/modern-go/reflect2
+  version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
-- name: github.com/PuerkitoBio/purell
-  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
-- name: github.com/PuerkitoBio/urlesc
-  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
+- name: github.com/prometheus/client_golang
+  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
+  subpackages:
+  - prometheus
+  - prometheus/promhttp
+- name: github.com/prometheus/client_model
+  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  subpackages:
+  - go
+- name: github.com/prometheus/common
+  version: 13ba4ddd0caa9c28ca7b7bffe1dfa9ed8d5ef207
+  subpackages:
+  - expfmt
+  - internal/bitbucket.org/ww/goautoneg
+  - model
+- name: github.com/prometheus/procfs
+  version: 65c1f6f8f0fc1e2185eb9863a3bc751496404259
+  subpackages:
+  - xfs
 - name: github.com/satori/go.uuid
-  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/spf13/pflag
-  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+  version: 583c0c0531f06d5278b7d917446061adc344b5cd
+- name: github.com/thinkerou/favicon
+  version: 94a442a49da6e2d44bdd5e0d2e2e185c43a19d93
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: go.uber.org/atomic
-  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
+  version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/multierr
   version: 3c4937480c32f4c13a875a1829af76c98ca3d40a
 - name: go.uber.org/zap
@@ -161,9 +187,15 @@ imports:
   - internal/exit
   - zapcore
 - name: golang.org/x/crypto
-  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
+  - acme
+  - acme/autocert
   - ssh/terminal
+- name: golang.org/x/lint
+  version: 8f45f776aaf18cebc8d65861cc70c33c60471952
+  subpackages:
+  - golint
 - name: golang.org/x/net
   version: 1c05540f6879653db88113bc4a2b70aec4bd491f
   subpackages:
@@ -173,27 +205,77 @@ imports:
   - http2
   - http2/hpack
   - idna
+  - internal/timeseries
   - lex/httplex
+  - trace
   - websocket
+- name: golang.org/x/oauth2
+  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
 - name: golang.org/x/sys
-  version: a2e06a18b0d52d8cb2010e04b372a1965d8e3439
+  version: 95c6576299259db960f6c5b9b69ea52422860fce
   subpackages:
   - unix
   - windows
 - name: golang.org/x/text
   version: b19bf474d317b857955b12035d2c5acb57ce8b01
   subpackages:
-  - cases
-  - internal
-  - internal/tag
-  - language
-  - runes
   - secure/bidirule
-  - secure/precis
   - transform
   - unicode/bidi
   - unicode/norm
-  - width
+- name: golang.org/x/time
+  version: f51c12702a4d776e4c1fa9b0fabab841babae631
+  subpackages:
+  - rate
+- name: golang.org/x/tools
+  version: 2382e3994d48b1d22acc2c86bcad0a2aff028e32
+  subpackages:
+  - benchmark/parse
+  - container/intsets
+  - go/ast/astutil
+  - go/gcexportdata
+  - go/gcimporter15
+  - go/vcs
+  - imports
+- name: google.golang.org/appengine
+  version: e9657d882bb81064595ca3b56cbe2546bbabf7b1
+  subpackages:
+  - internal
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  subpackages:
+  - googleapis/api/annotations
+  - googleapis/rpc/status
+- name: google.golang.org/grpc
+  version: 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e
+  subpackages:
+  - balancer
+  - codes
+  - connectivity
+  - credentials
+  - grpclb/grpc_lb_v1/messages
+  - grpclog
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - resolver
+  - stats
+  - status
+  - tap
+  - transport
 - name: gopkg.in/go-playground/validator.v8
   version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
@@ -201,9 +283,9 @@ imports:
 - name: gopkg.in/natefinch/lumberjack.v2
   version: a96e63847dc3c67d17befa69c303767e2f84e54f
 - name: gopkg.in/yaml.v2
-  version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+  version: 670d4cfef0544295bc27a114dbac37980d83185a
 - name: k8s.io/api
-  version: 006a217681ae70cbacdd66a5e2fca1a61a8ff28e
+  version: d1dc89ebaebe945edbeff52a79f50c791a59ff87
   subpackages:
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
@@ -216,10 +298,12 @@ imports:
   - authorization/v1beta1
   - autoscaling/v1
   - autoscaling/v2beta1
+  - autoscaling/v2beta2
   - batch/v1
   - batch/v1beta1
   - batch/v2alpha1
   - certificates/v1beta1
+  - coordination/v1beta1
   - core/v1
   - events/v1beta1
   - extensions/v1beta1
@@ -229,12 +313,13 @@ imports:
   - rbac/v1alpha1
   - rbac/v1beta1
   - scheduling/v1alpha1
+  - scheduling/v1beta1
   - settings/v1alpha1
   - storage/v1
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: 68f9c3a1feb3140df59c67ced62d3a5df8e6c9c2
+  version: f71dbbc36e126f5a371b85f6cca96bc8c57db2b6
   subpackages:
   - pkg/api/errors
   - pkg/api/meta
@@ -242,7 +327,7 @@ imports:
   - pkg/apis/meta/internalversion
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
-  - pkg/apis/meta/v1alpha1
+  - pkg/apis/meta/v1beta1
   - pkg/conversion
   - pkg/conversion/queryparams
   - pkg/fields
@@ -265,6 +350,7 @@ imports:
   - pkg/util/intstr
   - pkg/util/json
   - pkg/util/mergepatch
+  - pkg/util/naming
   - pkg/util/net
   - pkg/util/runtime
   - pkg/util/sets
@@ -278,13 +364,55 @@ imports:
   - pkg/watch
   - third_party/forked/golang/json
   - third_party/forked/golang/reflect
-  - util/validation
-  - util/validation/field
 - name: k8s.io/client-go
-  version: 9389c055a838d4f208b699b3c7c51b70f2368861
+  version: bf181536cb4da7eeb6ed732fcf79ecf0e36efaa2
   subpackages:
   - discovery
   - discovery/fake
+  - informers
+  - informers/admissionregistration
+  - informers/admissionregistration/v1alpha1
+  - informers/admissionregistration/v1beta1
+  - informers/apps
+  - informers/apps/v1
+  - informers/apps/v1beta1
+  - informers/apps/v1beta2
+  - informers/autoscaling
+  - informers/autoscaling/v1
+  - informers/autoscaling/v2beta1
+  - informers/autoscaling/v2beta2
+  - informers/batch
+  - informers/batch/v1
+  - informers/batch/v1beta1
+  - informers/batch/v2alpha1
+  - informers/certificates
+  - informers/certificates/v1beta1
+  - informers/coordination
+  - informers/coordination/v1beta1
+  - informers/core
+  - informers/core/v1
+  - informers/events
+  - informers/events/v1beta1
+  - informers/extensions
+  - informers/extensions/v1beta1
+  - informers/internalinterfaces
+  - informers/networking
+  - informers/networking/v1
+  - informers/policy
+  - informers/policy/v1beta1
+  - informers/rbac
+  - informers/rbac/v1
+  - informers/rbac/v1alpha1
+  - informers/rbac/v1beta1
+  - informers/scheduling
+  - informers/scheduling/v1alpha1
+  - informers/scheduling/v1beta1
+  - informers/settings
+  - informers/settings/v1alpha1
+  - informers/storage
+  - informers/storage/v1
+  - informers/storage/v1alpha1
+  - informers/storage/v1beta1
   - kubernetes
   - kubernetes/fake
   - kubernetes/scheme
@@ -310,6 +438,8 @@ imports:
   - kubernetes/typed/autoscaling/v1/fake
   - kubernetes/typed/autoscaling/v2beta1
   - kubernetes/typed/autoscaling/v2beta1/fake
+  - kubernetes/typed/autoscaling/v2beta2
+  - kubernetes/typed/autoscaling/v2beta2/fake
   - kubernetes/typed/batch/v1
   - kubernetes/typed/batch/v1/fake
   - kubernetes/typed/batch/v1beta1
@@ -318,6 +448,8 @@ imports:
   - kubernetes/typed/batch/v2alpha1/fake
   - kubernetes/typed/certificates/v1beta1
   - kubernetes/typed/certificates/v1beta1/fake
+  - kubernetes/typed/coordination/v1beta1
+  - kubernetes/typed/coordination/v1beta1/fake
   - kubernetes/typed/core/v1
   - kubernetes/typed/core/v1/fake
   - kubernetes/typed/events/v1beta1
@@ -336,6 +468,8 @@ imports:
   - kubernetes/typed/rbac/v1beta1/fake
   - kubernetes/typed/scheduling/v1alpha1
   - kubernetes/typed/scheduling/v1alpha1/fake
+  - kubernetes/typed/scheduling/v1beta1
+  - kubernetes/typed/scheduling/v1beta1/fake
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/settings/v1alpha1/fake
   - kubernetes/typed/storage/v1
@@ -344,7 +478,38 @@ imports:
   - kubernetes/typed/storage/v1alpha1/fake
   - kubernetes/typed/storage/v1beta1
   - kubernetes/typed/storage/v1beta1/fake
+  - listers/admissionregistration/v1alpha1
+  - listers/admissionregistration/v1beta1
+  - listers/apps/v1
+  - listers/apps/v1beta1
+  - listers/apps/v1beta2
+  - listers/autoscaling/v1
+  - listers/autoscaling/v2beta1
+  - listers/autoscaling/v2beta2
+  - listers/batch/v1
+  - listers/batch/v1beta1
+  - listers/batch/v2alpha1
+  - listers/certificates/v1beta1
+  - listers/coordination/v1beta1
+  - listers/core/v1
+  - listers/events/v1beta1
+  - listers/extensions/v1beta1
+  - listers/networking/v1
+  - listers/policy/v1beta1
+  - listers/rbac/v1
+  - listers/rbac/v1alpha1
+  - listers/rbac/v1beta1
+  - listers/scheduling/v1alpha1
+  - listers/scheduling/v1beta1
+  - listers/settings/v1alpha1
+  - listers/storage/v1
+  - listers/storage/v1alpha1
+  - listers/storage/v1beta1
+  - pkg/apis/clientauthentication
+  - pkg/apis/clientauthentication/v1alpha1
+  - pkg/apis/clientauthentication/v1beta1
   - pkg/version
+  - plugin/pkg/client/auth/exec
   - rest
   - rest/watch
   - testing
@@ -354,6 +519,8 @@ imports:
   - tools/clientcmd/api
   - tools/clientcmd/api/latest
   - tools/clientcmd/api/v1
+  - tools/leaderelection
+  - tools/leaderelection/resourcelock
   - tools/metrics
   - tools/pager
   - tools/record
@@ -361,29 +528,28 @@ imports:
   - transport
   - util/buffer
   - util/cert
+  - util/connrotation
   - util/flowcontrol
   - util/homedir
   - util/integer
+  - util/retry
+  - util/workqueue
 - name: k8s.io/kube-openapi
-  version: 39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1
+  version: 0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803
   subpackages:
-  - pkg/common
   - pkg/util/proto
 - name: k8s.io/kubernetes
-  version: 5fa2db2bd46ac79e5e00a4e6ed24191080aa463b
+  version: 17c77c7898218073f14c8d573582e8d2313dc740
   subpackages:
   - pkg/apis/core
   - pkg/apis/core/helper
   - pkg/apis/core/v1/helper
   - pkg/util/goroutinemap
-  - pkg/util/goroutinemap/exponentialbackoff
+  - pkg/util/io
+  - pkg/util/mount
   - pkg/util/version
 testImports:
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,45 +1,43 @@
 package: github.com/IBM/ibmcloud-object-storage-plugin
 import:
 - package: github.com/golang/glog
-- package: k8s.io/apimachinery
-  subpackages:
-  - util/validation
-  - util/validation/field
 - package: github.com/kubernetes-incubator/external-storage
-  version: ^1.8.1
+  version: v5.2.0
+- package: github.com/satori/go.uuid
+  version: v1.2.0
+- package: k8s.io/api
+  version: kubernetes-1.12.2
+- package: k8s.io/apimachinery
+  version: kubernetes-1.12.2
+- package: k8s.io/client-go
+  version: kubernetes-1.12.2
+- package: k8s.io/kubernetes
+  version: 17c77c7898218073f14c8d573582e8d2313dc740 
   subpackages:
-  - lib/controller
+  - pkg/apis/core
+  - pkg/apis/core/helper
+  - pkg/apis/core/v1/helper
+  - pkg/util/goroutinemap
+  - pkg/util/io
+  - pkg/util/mount
+  - pkg/util/version
 - package: github.com/aws/aws-sdk-go
   version: b90ee7ac719c7dec882a13e4c18c59bc1798ddfe
   repo: https://github.com/orozery/aws-sdk-go.git
-  subpackages:
-  - aws/credentials
-  - aws/credentials/ibmcreds
-  - aws
-  - service/s3
-  - session
-  - aws/session
-  - aws/awserr
 - package: gopkg.in/natefinch/lumberjack.v2
-  version: ^2.1.0
+  version: v2.1.0
 - package: go.uber.org/zap
-  version: ^1.8.0
+  version: v1.8.0
   subpackages:
   - zapcore
-- package: k8s.io/kubernetes
-  version: v1.9.2
-- package: k8s.io/client-go
-  version: kubernetes-1.9.2
-  subpackages:
-  - kubernetes
-  - tools/clientcmd
-  - rest
-  - kubernetes/fake
 - package: github.com/jessevdk/go-flags
+  version: v1.4.0
 testImport:
 - package: github.com/stretchr/testify
-  version: 1.2.1
+  version: v1.2.2
   subpackages:
   - assert
 - package: github.com/coreos/go-systemd/dbus
 - package: github.com/godbus/dbus
+excludeDirs:
+- tests

--- a/images/driver/Dockerfile.builder
+++ b/images/driver/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.9.1
+FROM golang:1.10.7
 
 # Default values
 ARG git_commit_id=unknown

--- a/images/provisioner/Dockerfile
+++ b/images/provisioner/Dockerfile
@@ -4,16 +4,12 @@ FROM alpine:3.7
 ARG git_commit_id=unknown
 ARG git_remote_url=unknown
 ARG build_date=unknown
-ARG jenkins_build_id=unknown
-ARG jenkins_build_number=unknown
 ARG travis_build_number=unknown
 
 # Add Labels to image to show build details
 LABEL git-commit-id=${git_commit_id}
 LABEL git-remote-url=${git_remote_url}
 LABEL build-date=${build_date}
-LABEL jenkins-build-id=${jenkins_build_id}
-LABEL jenkins-build-number=${jenkins_build_number}
 LABEL travis_build_number=${travis_build_number}
 
 # Add the Provisioner executable

--- a/images/provisioner/Dockerfile
+++ b/images/provisioner/Dockerfile
@@ -4,11 +4,17 @@ FROM alpine:3.7
 ARG git_commit_id=unknown
 ARG git_remote_url=unknown
 ARG build_date=unknown
+ARG jenkins_build_id=unknown
+ARG jenkins_build_number=unknown
+ARG travis_build_number=unknown
 
 # Add Labels to image to show build details
 LABEL git-commit-id=${git_commit_id}
 LABEL git-remote-url=${git_remote_url}
 LABEL build-date=${build_date}
+LABEL jenkins-build-id=${jenkins_build_id}
+LABEL jenkins-build-number=${jenkins_build_number}
+LABEL travis_build_number=${travis_build_number}
 
 # Add the Provisioner executable
 ADD ca-certs.tar.gz /

--- a/images/provisioner/Dockerfile.builder
+++ b/images/provisioner/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.9.1
+FROM golang:1.10.7
 ADD . /go/src/github.com/IBM/ibmcloud-object-storage-plugin
 RUN set -ex; cd /go/src/github.com/IBM/ibmcloud-object-storage-plugin/ && CGO_ENABLED=0 go install -v github.com/IBM/ibmcloud-object-storage-plugin/cmd/provisioner
 RUN set -ex; tar cvC / ./etc/ssl  | gzip -n > /root/ca-certs.tar.gz

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -339,10 +339,10 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 				v1.ResourceStorage: options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],
 			},
 			PersistentVolumeSource: v1.PersistentVolumeSource{
-				FlexVolume: &v1.FlexVolumeSource{
+				FlexVolume: &v1.FlexPersistentVolumeSource{
 					Driver:    driverName,
 					FSType:    fsType,
-					SecretRef: &v1.LocalObjectReference{Name: pvc.SecretName},
+					SecretRef: &v1.SecretReference{Name: pvc.SecretName},
 					ReadOnly:  false,
 					Options:   driverOptions,
 				},

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -215,7 +215,7 @@ func getAutoDeletePersistentVolume() *v1.PersistentVolume {
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
-				FlexVolume: &v1.FlexVolumeSource{
+				FlexVolume: &v1.FlexPersistentVolumeSource{
 					Options: map[string]string{"object-store-endpoint": testOSEndpoint, "object-store-storage-class": testStorageClass},
 				},
 			},


### PR DESCRIPTION
What this PR does / why we need it:
This PR upgrades glide dependencies, go lang version and disable LeaderElection

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

Special notes for your reviewer:
Tested with K8S cluster deployed in IBM Cloud Kubernetes Service