### PR TITLE
Use 'kubernetes-sigs/sig-storage-lib-external-provisioner' library instead of 'kubernetes-incubator/external-storage'

### DIFF
--- a/cmd/provisioner/main.go
+++ b/cmd/provisioner/main.go
@@ -20,7 +20,7 @@ import (
 	cfg "github.com/IBM/ibmcloud-object-storage-plugin/utils/config"
 	log "github.com/IBM/ibmcloud-object-storage-plugin/utils/logger"
 	"github.com/IBM/ibmcloud-object-storage-plugin/utils/uuid"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9665b7a014c723da4fe358c69f24c39806efcd6d1ded62f9b4e51adcbe19cdbb
-updated: 2018-12-19T10:24:26.693416123-08:00
+hash: 47e4549d513351e14b6608b3b3ba37518a76ade6af5f23834b6d8f339f7fb50e
+updated: 2019-03-12T03:04:06.351834973-07:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: b90ee7ac719c7dec882a13e4c18c59bc1798ddfe
@@ -38,42 +38,16 @@ imports:
   - quantile
 - name: github.com/BurntSushi/toml
   version: 3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005
-- name: github.com/campoy/embedmd
-  version: 97c13d6e41602fc6e397eb51c45f38069371a969
-  subpackages:
-  - embedmd
-- name: github.com/client9/misspell
-  version: 9ce5d979ffdaca6385988d7ad1079a33ec942d20
-  subpackages:
-  - cmd/misspell
-- name: github.com/coreos/go-systemd
-  version: 9002847aa1425fb6ac49077c0a630b3b67e0fbfd
-  subpackages:
-  - dbus
 - name: github.com/davecgh/go-spew
   version: 782f4967f2dc4564575ca782fe2d04090b5faca8
   subpackages:
   - spew
-- name: github.com/dustin/go-broadcast
-  version: f664265f5a662fb4d1df7f3533b1e8d0e0277120
-- name: github.com/ghodss/yaml
-  version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
-- name: github.com/gin-contrib/sse
-  version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
-- name: github.com/gin-gonic/autotls
-  version: be87bd5ef97b7398e468c35ad266aabf099a095b
-- name: github.com/gin-gonic/gin
-  version: 1542eff27f7d67ef56543358e2f623eb4ea8adf9
-  subpackages:
-  - binding
-  - internal/json
-  - render
+- name: github.com/evanphx/json-patch
+  version: 5858425f75500d40c52783dce87d085a483ce135
 - name: github.com/go-ini/ini
   version: 300e940a926eb277d3901b20bdfcc54928ad3642
-- name: github.com/godbus/dbus
-  version: e25f905dbfbcdbc1fe19a684d9fe2a1261383ef8
 - name: github.com/gogo/protobuf
-  version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
+  version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
   - proto
   - sortkeys
@@ -111,40 +85,32 @@ imports:
   - simplelru
 - name: github.com/imdario/mergo
   version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
-- name: github.com/jessevdk/go-assets
-  version: 4f4301a06e153ff90e17793577ab6bf79f8dc5c5
 - name: github.com/jessevdk/go-flags
   version: c6ca198ec95c841fdb89fc0de7496fed11ab854e
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
 - name: github.com/json-iterator/go
-  version: f2b4162afba35581b6d4a50d3b8f34e33c144682
-- name: github.com/kubernetes-incubator/external-storage
-  version: 193fb3944bf3061e59ae072ab7511861e8868553
+  version: ab8a2e0c74be9d3be70b3184d9acc634935ded82
+- name: github.com/kubernetes-sigs/sig-storage-lib-external-provisioner
+  version: 99ac517d9c047238af8b8a6c411084b9f7888a87
   subpackages:
-  - lib/controller
-  - lib/controller/metrics
-  - lib/util
-- name: github.com/manucorporat/stats
-  version: 3ba42d56d227cf2a6086b63baba5e00669235853
-- name: github.com/mattn/go-isatty
-  version: 3fb116b820352b7f0c281308a4d6250c22d94e27
+  - controller
+  - controller/metrics
+  - util
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
+- name: github.com/miekg/dns
+  version: 72df20724eec4158987b19c4e5045f1f1b870ab6
 - name: github.com/modern-go/concurrent
   version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
 - name: github.com/modern-go/reflect2
-  version: 05fbef0ca5da472bbf96c9322b84a53edc03c9fd
+  version: 94122c33edd36123c84d5368cfb2b69df93a0ec8
 - name: github.com/pborman/uuid
   version: ca53cad383cad2479bbba7f7a1a05797ec1386e4
 - name: github.com/peterbourgon/diskv
   version: 5f041e8faa004a95c88a202771f4cc3e991971e6
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
 - name: github.com/prometheus/client_golang
   version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
   subpackages:
@@ -168,12 +134,6 @@ imports:
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/spf13/pflag
   version: 583c0c0531f06d5278b7d917446061adc344b5cd
-- name: github.com/thinkerou/favicon
-  version: 94a442a49da6e2d44bdd5e0d2e2e185c43a19d93
-- name: github.com/ugorji/go
-  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
-  subpackages:
-  - codec
 - name: go.uber.org/atomic
   version: 1ea20fb1cbb1cc08cbd0d913a96dead89aa18289
 - name: go.uber.org/multierr
@@ -189,25 +149,24 @@ imports:
 - name: golang.org/x/crypto
   version: de0752318171da717af4ce24d0a2e8626afaeb11
   subpackages:
-  - acme
-  - acme/autocert
+  - ed25519
+  - ed25519/internal/edwards25519
   - ssh/terminal
-- name: golang.org/x/lint
-  version: 8f45f776aaf18cebc8d65861cc70c33c60471952
-  subpackages:
-  - golint
 - name: golang.org/x/net
-  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
+  - bpf
   - context
   - html
   - html/atom
   - http2
   - http2/hpack
   - idna
-  - internal/timeseries
+  - internal/iana
+  - internal/socket
+  - ipv4
+  - ipv6
   - lex/httplex
-  - trace
   - websocket
 - name: golang.org/x/oauth2
   version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
@@ -232,16 +191,6 @@ imports:
   version: f51c12702a4d776e4c1fa9b0fabab841babae631
   subpackages:
   - rate
-- name: golang.org/x/tools
-  version: 2382e3994d48b1d22acc2c86bcad0a2aff028e32
-  subpackages:
-  - benchmark/parse
-  - container/intsets
-  - go/ast/astutil
-  - go/gcexportdata
-  - go/gcimporter15
-  - go/vcs
-  - imports
 - name: google.golang.org/appengine
   version: e9657d882bb81064595ca3b56cbe2546bbabf7b1
   subpackages:
@@ -252,46 +201,21 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: google.golang.org/genproto
-  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
-  subpackages:
-  - googleapis/api/annotations
-  - googleapis/rpc/status
-- name: google.golang.org/grpc
-  version: 5b3c4e850e90a4cf6a20ebd46c8b32a0a3afcb9e
-  subpackages:
-  - balancer
-  - codes
-  - connectivity
-  - credentials
-  - grpclb/grpc_lb_v1/messages
-  - grpclog
-  - internal
-  - keepalive
-  - metadata
-  - naming
-  - peer
-  - resolver
-  - stats
-  - status
-  - tap
-  - transport
-- name: gopkg.in/go-playground/validator.v8
-  version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/natefinch/lumberjack.v2
   version: a96e63847dc3c67d17befa69c303767e2f84e54f
 - name: gopkg.in/yaml.v2
-  version: 670d4cfef0544295bc27a114dbac37980d83185a
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
 - name: k8s.io/api
-  version: d1dc89ebaebe945edbeff52a79f50c791a59ff87
+  version: 5cb15d34447165a97c76ed5a60e4e99c8a01ecfe
   subpackages:
   - admissionregistration/v1alpha1
   - admissionregistration/v1beta1
   - apps/v1
   - apps/v1beta1
   - apps/v1beta2
+  - auditregistration/v1alpha1
   - authentication/v1
   - authentication/v1beta1
   - authorization/v1
@@ -319,7 +243,7 @@ imports:
   - storage/v1alpha1
   - storage/v1beta1
 - name: k8s.io/apimachinery
-  version: f71dbbc36e126f5a371b85f6cca96bc8c57db2b6
+  version: 86fb29eff6288413d76bd8506874fddd9fccdff0
   subpackages:
   - pkg/api/errors
   - pkg/api/meta
@@ -358,6 +282,7 @@ imports:
   - pkg/util/uuid
   - pkg/util/validation
   - pkg/util/validation/field
+  - pkg/util/version
   - pkg/util/wait
   - pkg/util/yaml
   - pkg/version
@@ -365,7 +290,7 @@ imports:
   - third_party/forked/golang/json
   - third_party/forked/golang/reflect
 - name: k8s.io/client-go
-  version: bf181536cb4da7eeb6ed732fcf79ecf0e36efaa2
+  version: b40b2a5939e43f7ffe0028ad67586b7ce50bb675
   subpackages:
   - discovery
   - discovery/fake
@@ -377,6 +302,8 @@ imports:
   - informers/apps/v1
   - informers/apps/v1beta1
   - informers/apps/v1beta2
+  - informers/auditregistration
+  - informers/auditregistration/v1alpha1
   - informers/autoscaling
   - informers/autoscaling/v1
   - informers/autoscaling/v2beta1
@@ -426,6 +353,8 @@ imports:
   - kubernetes/typed/apps/v1beta1/fake
   - kubernetes/typed/apps/v1beta2
   - kubernetes/typed/apps/v1beta2/fake
+  - kubernetes/typed/auditregistration/v1alpha1
+  - kubernetes/typed/auditregistration/v1alpha1/fake
   - kubernetes/typed/authentication/v1
   - kubernetes/typed/authentication/v1/fake
   - kubernetes/typed/authentication/v1beta1
@@ -483,6 +412,7 @@ imports:
   - listers/apps/v1
   - listers/apps/v1beta1
   - listers/apps/v1beta2
+  - listers/auditregistration/v1alpha1
   - listers/autoscaling/v1
   - listers/autoscaling/v2beta1
   - listers/autoscaling/v2beta2
@@ -534,12 +464,14 @@ imports:
   - util/integer
   - util/retry
   - util/workqueue
+- name: k8s.io/klog
+  version: 8139d8cb77af419532b33dfa7dd09fbc5f1d344f
 - name: k8s.io/kube-openapi
-  version: 0cf8f7e6ed1d2e3d47d02e3b6e559369af24d803
+  version: c59034cc13d587f5ef4e85ca0ade0c1866ae8e1d
   subpackages:
   - pkg/util/proto
 - name: k8s.io/kubernetes
-  version: 17c77c7898218073f14c8d573582e8d2313dc740
+  version: c27b913fddd1a6c480c229191a087698aa92f0b1
   subpackages:
   - pkg/apis/core
   - pkg/apis/core/helper
@@ -548,7 +480,19 @@ imports:
   - pkg/util/io
   - pkg/util/mount
   - pkg/util/version
+- name: sigs.k8s.io/yaml
+  version: fd68e9863619f6ec2fdd8625fe1f02e7c877e480
 testImports:
+- name: github.com/coreos/go-systemd
+  version: 9002847aa1425fb6ac49077c0a630b3b67e0fbfd
+  subpackages:
+  - dbus
+- name: github.com/godbus/dbus
+  version: e25f905dbfbcdbc1fe19a684d9fe2a1261383ef8
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/stretchr/testify
   version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,18 +1,18 @@
 package: github.com/IBM/ibmcloud-object-storage-plugin
 import:
 - package: github.com/golang/glog
-- package: github.com/kubernetes-incubator/external-storage
-  version: v5.2.0
+- package: github.com/kubernetes-sigs/sig-storage-lib-external-provisioner
+  version: v2.2.0
 - package: github.com/satori/go.uuid
   version: v1.2.0
 - package: k8s.io/api
-  version: kubernetes-1.12.2
+  version: kubernetes-1.13.4
 - package: k8s.io/apimachinery
-  version: kubernetes-1.12.2
+  version: kubernetes-1.13.4
 - package: k8s.io/client-go
-  version: kubernetes-1.12.2
+  version: kubernetes-1.13.4
 - package: k8s.io/kubernetes
-  version: 17c77c7898218073f14c8d573582e8d2313dc740 
+  version: c27b913fddd1a6c480c229191a087698aa92f0b1
   subpackages:
   - pkg/apis/core
   - pkg/apis/core/helper

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -18,7 +18,7 @@ import (
 	"github.com/IBM/ibmcloud-object-storage-plugin/utils/logger"
 	"github.com/IBM/ibmcloud-object-storage-plugin/utils/parser"
 	"github.com/IBM/ibmcloud-object-storage-plugin/utils/uuid"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"go.uber.org/zap"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/IBM/ibmcloud-object-storage-plugin/utils/backend"
 	"github.com/IBM/ibmcloud-object-storage-plugin/utils/backend/fake"
 	"github.com/IBM/ibmcloud-object-storage-plugin/utils/uuid"
-	"github.com/kubernetes-incubator/external-storage/lib/controller"
+	"github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/controller"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
What this PR does / why we need it:
This PR is to replace pkg `kubernetes-incubator/external-storage` with `kubernetes-sigs/sig-storage-lib-external-provisioner` as 
**kubernetes-incubator/external-storage/lib is deprecated. The library has moved to kubernetes-sigs/sig-storage-lib-external-provisioner.**

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

Special notes for your reviewer:
Tested with K8S cluster deployed in IBM Cloud Kubernetes Service