### PR TITLE
Suppport for few s3fs options from pvc yaml file + Bug fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - "1.10.7"
+  - "1.11.5"
   - tip
 
 group: bluezone

--- a/Makefile
+++ b/Makefile
@@ -102,4 +102,4 @@ test-integration:
 
 .PHONY: clean
 clean:
-rm -f ibmcloud-object-storage-plugin
+	rm -f ibmcloud-object-storage-plugin

--- a/Makefile
+++ b/Makefile
@@ -6,43 +6,28 @@
 # * disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 # ******************************************************************************
 
-IMAGE = ibmcloud-object-storage-plugin
+PROVISIONER_CONT_IMG=armada-master/ibmcloud-object-storage-plugin
+DRIVER_CONT_IMG=armada-master/ibmcloud-object-storage-driver
 
-VERSION :=
-TAG := $(shell git describe --abbrev=0 --tags HEAD 2>/dev/null)
-COMMIT := $(shell git rev-parse HEAD)
-GOPACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /cmd)
+# TAG := $(shell git describe --abbrev=0 --tags HEAD 2>/dev/null)
+# COMMIT := $(shell git rev-parse HEAD)
+
+GOPACKAGES=$(shell go list ./... | grep -v '/cmd\|/pkg\|/s3fs-mount-health\|/vendor\|/tests')
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 GIT_COMMIT_SHA="$(shell git rev-parse HEAD 2>/dev/null)"
 GIT_REMOTE_URL="$(shell git config --get remote.origin.url 2>/dev/null)"
 BUILD_DATE="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")"
-
-#ifeq ($(TAG),)
-#    VERSION := latest
-#else
-#    ifeq ($(COMMIT), $(shell git rev-list -n1 $(TAG)))
-#        VERSION := $(TAG)
-#    else
-#        VERSION := $(TAG)-$(COMMIT)
-#    endif
-#endif
-VERSION := latest
+#IMAGE_TAG="$(shell awk '{print $$2}' VERSION)"
+IMAGE_TAG := latest
+# Jenkins vars. Set to `unknown` if the variable is not yet defined
+BUILD_ID?=unknown
+BUILD_NUMBER?=unknown
+TRAVIS_BUILD_NUMBER?=unknown
+#VERSION := latest
 
 .PHONY: all
 all: deps fmt vet test
-
-.PHONY: provisioner
-provisioner: deps buildprovisioner
-
-.PHONY: driver
-driver: deps builddriver
-
-.PHONY: deps
-deps:
-	echo "Installing dependencies ..."
-	glide install --strip-vendor
-	go get github.com/pierrre/gotestcover
 
 .PHONY: fmt
 fmt:
@@ -55,46 +40,102 @@ vet:
 
 .PHONY: test
 test:
+	mkdir /tmp/s3fs
 	$(GOPATH)/bin/gotestcover -v -race -coverprofile=cover.out ${GOPACKAGES}
-
-.PHONY: coverage
-coverage:
 	go tool cover -html=cover.out -o=cover.html
+	rm -rf /tmp/s3fs
 
-.PHONY: buildgo
-buildgo:
-	go build
+.PHONY: deps
+deps:
+	echo "Installing dependencies ..."
+	glide install --strip-vendor
+	go get github.com/pierrre/gotestcover
 
-.PHONY: buildprovisioner
-buildprovisioner:
-	#Build provisioner executable on target env
-	docker build -t provisioner-builder --pull -f images/provisioner/Dockerfile.builder .
-	docker run provisioner-builder /bin/true
+.PHONY: ut-coverage
+ut-coverage: deps fmt vet test
+
+# Build provisioner and driver images
+.PHONY: plugin-images-build
+plugin-images-build: build-provisioner-image build-driver-image
+	# Tag and push image to user registry
+	docker tag $(PROVISIONER_CONT_IMG):$(IMAGE_TAG) $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(PLUGIN_IMAGE):$(PLUGIN_BUILD)
+	docker push $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(PLUGIN_IMAGE):$(PLUGIN_BUILD)
+
+	docker tag $(DRIVER_CONT_IMG):$(IMAGE_TAG) $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(DRIVER_IMAGE):$(DRIVER_BUILD)
+	docker push $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(DRIVER_IMAGE):$(DRIVER_BUILD)
+
+.PHONY: build-provisioner-image
+build-provisioner-image: deps
+	# Spin provisioner builder container
+	docker build -t provisioner-builder:latest -f images/provisioner/Dockerfile.builder . && sleep 30
+	docker run provisioner-builder:latest  /bin/true
 	docker cp `docker ps -q -n=1`:/root/ca-certs.tar.gz ./
 	docker cp `docker ps -q -n=1`:/root/provisioner.tar.gz ./
 
-	#Make the final docker build having iscsilib and provisioner
+	# Build Provisioner container image
 	docker build \
         --build-arg git_commit_id=${GIT_COMMIT_SHA} \
         --build-arg git_remote_url=${GIT_REMOTE_URL} \
         --build-arg build_date=${BUILD_DATE} \
-        -t $(IMAGE):$(VERSION) -f ./images/provisioner/Dockerfile .
+        --build-arg jenkins_build_id=${BUILD_ID} \
+        --build-arg jenkins_build_number=${BUILD_NUMBER} \
+	--build-arg travis_build_number=${TRAVIS_BUILD_NUMBER} \
+        -t $(PROVISIONER_CONT_IMG):$(IMAGE_TAG) -f ./images/provisioner/Dockerfile .
 
-	#Cleanup
+	# Cleanup
 	rm -f provisioner.tar.gz
 	rm -f ca-certs.tar.gz
 
-.PHONY: builddriver
-builddriver:
-	#Build and copy executables
-	docker build --build-arg git_commit_id=${GIT_COMMIT_SHA} --build-arg build_date=${BUILD_DATE} -t driver-builder --pull -f images/driver/Dockerfile.builder .
+# Build Driver container image
+.PHONY: build-driver-image
+build-driver-image: build-fuse-binary copy-driver-binaries
+	rm -rf s3fs-fuse
+	docker build --build-arg git_commit_id=${GIT_COMMIT_SHA} \
+        --build-arg git_remote_url=${GIT_REMOTE_URL} \
+        --build-arg build_date=${BUILD_DATE} \
+        --build-arg jenkins_build_id=${BUILD_ID} \
+        --build-arg jenkins_build_number=${BUILD_NUMBER} \
+	--build-arg travis_build_number=${TRAVIS_BUILD_NUMBER} \
+        -t $(DRIVER_CONT_IMG):$(IMAGE_TAG)  ./pkg/
+
+# Build fuse binary
+.PHONY: build-fuse-binary
+build-fuse-binary:
+	git clone https://github.com/s3fs-fuse/s3fs-fuse.git
+	docker build -t fuse:ubuntu16 -f ./images/driver/Dockerfile.ubuntu16 . && sleep 30
+	docker run fuse:ubuntu16  /bin/true
+	docker cp `docker ps -q -n=1`:/s3fs-fuse/src/s3fs ./s3fs16
+
+	docker build -t fuse:ubuntu18 -f ./images/driver/Dockerfile.ubuntu18 . && sleep 30
+	docker run fuse:ubuntu18  /bin/true
+	docker cp `docker ps -q -n=1`:/s3fs-fuse/src/s3fs ./s3fs18
+
+# Copy all binaries to be pushed with driver image
+.PHONY: copy-driver-binaries
+copy-driver-binaries: build-driver-binary
+	echo "---Driver Version---" > version.txt
+	$(GOPATH)/bin/ibmc-s3fs version >> version.txt
+	echo "---s3fs Fuse Version---" >> version.txt
+	./s3fs16 --version | head -n 1 >> version.txt
+	CC=$(which musl-gcc) go build -o systemutil --ldflags '-w -linkmode external -extldflags "-static"' pkg/systemutil.go
+	cp version.txt $(GOPATH)/bin/ibmc-s3fs s3fs16 s3fs18 systemutil ./pkg/
+
+.PHONY: build-driver-binary
+build-driver-binary: deps
+	# Spin driver builder container and generate driver binary
+	docker build --build-arg git_commit_id=${GIT_COMMIT_SHA} --build-arg build_date=${BUILD_DATE} \
+	-t driver-builder  -f images/driver/Dockerfile.builder . && sleep 30
 	docker run driver-builder /bin/true
 	docker cp `docker ps -q -n=1`:/go/bin/driver $(GOPATH)/bin/ibmc-s3fs
 	chmod 755 $(GOPATH)/bin/ibmc-s3fs
 
-.PHONY: push
-push:
-	docker push $(IMAGE):$(VERSION)
+# Execute e2e testcases
+.PHONY: test-binary-build-e2e
+test-binary-build-e2e:
+	#Install dependencies
+	apt-get -y install mercurial
+	cd ./tests/e2e; glide install -v
+	go test ./tests/e2e/basic -c -o $(E2E_TEST_BINARY)
 
 .PHONY: test-integration
 test-integration:
@@ -102,4 +143,4 @@ test-integration:
 
 .PHONY: clean
 clean:
-	rm -f ibmcloud-object-storage-plugin
+	rm -f armada-storage-s3fs-plugin

--- a/Makefile
+++ b/Makefile
@@ -6,28 +6,43 @@
 # * disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
 # ******************************************************************************
 
-PROVISIONER_CONT_IMG=armada-master/ibmcloud-object-storage-plugin
-DRIVER_CONT_IMG=armada-master/ibmcloud-object-storage-driver
+IMAGE = ibmcloud-object-storage-plugin
 
-# TAG := $(shell git describe --abbrev=0 --tags HEAD 2>/dev/null)
-# COMMIT := $(shell git rev-parse HEAD)
-
-GOPACKAGES=$(shell go list ./... | grep -v '/cmd\|/pkg\|/s3fs-mount-health\|/vendor\|/tests')
+VERSION :=
+TAG := $(shell git describe --abbrev=0 --tags HEAD 2>/dev/null)
+COMMIT := $(shell git rev-parse HEAD)
+GOPACKAGES=$(shell go list ./... | grep -v /vendor/ | grep -v /cmd)
 GOFILES=$(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
 GIT_COMMIT_SHA="$(shell git rev-parse HEAD 2>/dev/null)"
 GIT_REMOTE_URL="$(shell git config --get remote.origin.url 2>/dev/null)"
 BUILD_DATE="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")"
-#IMAGE_TAG="$(shell awk '{print $$2}' VERSION)"
-IMAGE_TAG := latest
-# Jenkins vars. Set to `unknown` if the variable is not yet defined
-BUILD_ID?=unknown
-BUILD_NUMBER?=unknown
-TRAVIS_BUILD_NUMBER?=unknown
-#VERSION := latest
+
+#ifeq ($(TAG),)
+#    VERSION := latest
+#else
+#    ifeq ($(COMMIT), $(shell git rev-list -n1 $(TAG)))
+#        VERSION := $(TAG)
+#    else
+#        VERSION := $(TAG)-$(COMMIT)
+#    endif
+#endif
+VERSION := latest
 
 .PHONY: all
 all: deps fmt vet test
+
+.PHONY: provisioner
+provisioner: deps buildprovisioner
+
+.PHONY: driver
+driver: deps builddriver
+
+.PHONY: deps
+deps:
+	echo "Installing dependencies ..."
+	glide install --strip-vendor
+	go get github.com/pierrre/gotestcover
 
 .PHONY: fmt
 fmt:
@@ -40,102 +55,46 @@ vet:
 
 .PHONY: test
 test:
-	mkdir /tmp/s3fs
 	$(GOPATH)/bin/gotestcover -v -race -coverprofile=cover.out ${GOPACKAGES}
+
+.PHONY: coverage
+coverage:
 	go tool cover -html=cover.out -o=cover.html
-	rm -rf /tmp/s3fs
 
-.PHONY: deps
-deps:
-	echo "Installing dependencies ..."
-	glide install --strip-vendor
-	go get github.com/pierrre/gotestcover
+.PHONY: buildgo
+buildgo:
+	go build
 
-.PHONY: ut-coverage
-ut-coverage: deps fmt vet test
-
-# Build provisioner and driver images
-.PHONY: plugin-images-build
-plugin-images-build: build-provisioner-image build-driver-image
-	# Tag and push image to user registry
-	docker tag $(PROVISIONER_CONT_IMG):$(IMAGE_TAG) $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(PLUGIN_IMAGE):$(PLUGIN_BUILD)
-	docker push $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(PLUGIN_IMAGE):$(PLUGIN_BUILD)
-
-	docker tag $(DRIVER_CONT_IMG):$(IMAGE_TAG) $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(DRIVER_IMAGE):$(DRIVER_BUILD)
-	docker push $(IMAGE_REGISTRY)/$(USER_NAMESPACE)/$(DRIVER_IMAGE):$(DRIVER_BUILD)
-
-.PHONY: build-provisioner-image
-build-provisioner-image: deps
-	# Spin provisioner builder container
-	docker build -t provisioner-builder:latest -f images/provisioner/Dockerfile.builder . && sleep 30
-	docker run provisioner-builder:latest  /bin/true
+.PHONY: buildprovisioner
+buildprovisioner:
+	#Build provisioner executable on target env
+	docker build -t provisioner-builder --pull -f images/provisioner/Dockerfile.builder .
+	docker run provisioner-builder /bin/true
 	docker cp `docker ps -q -n=1`:/root/ca-certs.tar.gz ./
 	docker cp `docker ps -q -n=1`:/root/provisioner.tar.gz ./
 
-	# Build Provisioner container image
+	#Make the final docker build having iscsilib and provisioner
 	docker build \
         --build-arg git_commit_id=${GIT_COMMIT_SHA} \
         --build-arg git_remote_url=${GIT_REMOTE_URL} \
         --build-arg build_date=${BUILD_DATE} \
-        --build-arg jenkins_build_id=${BUILD_ID} \
-        --build-arg jenkins_build_number=${BUILD_NUMBER} \
-	--build-arg travis_build_number=${TRAVIS_BUILD_NUMBER} \
-        -t $(PROVISIONER_CONT_IMG):$(IMAGE_TAG) -f ./images/provisioner/Dockerfile .
+        -t $(IMAGE):$(VERSION) -f ./images/provisioner/Dockerfile .
 
-	# Cleanup
+	#Cleanup
 	rm -f provisioner.tar.gz
 	rm -f ca-certs.tar.gz
 
-# Build Driver container image
-.PHONY: build-driver-image
-build-driver-image: build-fuse-binary copy-driver-binaries
-	rm -rf s3fs-fuse
-	docker build --build-arg git_commit_id=${GIT_COMMIT_SHA} \
-        --build-arg git_remote_url=${GIT_REMOTE_URL} \
-        --build-arg build_date=${BUILD_DATE} \
-        --build-arg jenkins_build_id=${BUILD_ID} \
-        --build-arg jenkins_build_number=${BUILD_NUMBER} \
-	--build-arg travis_build_number=${TRAVIS_BUILD_NUMBER} \
-        -t $(DRIVER_CONT_IMG):$(IMAGE_TAG)  ./pkg/
-
-# Build fuse binary
-.PHONY: build-fuse-binary
-build-fuse-binary:
-	git clone https://github.com/s3fs-fuse/s3fs-fuse.git
-	docker build -t fuse:ubuntu16 -f ./images/driver/Dockerfile.ubuntu16 . && sleep 30
-	docker run fuse:ubuntu16  /bin/true
-	docker cp `docker ps -q -n=1`:/s3fs-fuse/src/s3fs ./s3fs16
-
-	docker build -t fuse:ubuntu18 -f ./images/driver/Dockerfile.ubuntu18 . && sleep 30
-	docker run fuse:ubuntu18  /bin/true
-	docker cp `docker ps -q -n=1`:/s3fs-fuse/src/s3fs ./s3fs18
-
-# Copy all binaries to be pushed with driver image
-.PHONY: copy-driver-binaries
-copy-driver-binaries: build-driver-binary
-	echo "---Driver Version---" > version.txt
-	$(GOPATH)/bin/ibmc-s3fs version >> version.txt
-	echo "---s3fs Fuse Version---" >> version.txt
-	./s3fs16 --version | head -n 1 >> version.txt
-	CC=$(which musl-gcc) go build -o systemutil --ldflags '-w -linkmode external -extldflags "-static"' pkg/systemutil.go
-	cp version.txt $(GOPATH)/bin/ibmc-s3fs s3fs16 s3fs18 systemutil ./pkg/
-
-.PHONY: build-driver-binary
-build-driver-binary: deps
-	# Spin driver builder container and generate driver binary
-	docker build --build-arg git_commit_id=${GIT_COMMIT_SHA} --build-arg build_date=${BUILD_DATE} \
-	-t driver-builder  -f images/driver/Dockerfile.builder . && sleep 30
+.PHONY: builddriver
+builddriver:
+	#Build and copy executables
+	docker build --build-arg git_commit_id=${GIT_COMMIT_SHA} --build-arg build_date=${BUILD_DATE} -t driver-builder --pull -f images/driver/Dockerfile.builder .
 	docker run driver-builder /bin/true
 	docker cp `docker ps -q -n=1`:/go/bin/driver $(GOPATH)/bin/ibmc-s3fs
 	chmod 755 $(GOPATH)/bin/ibmc-s3fs
 
-# Execute e2e testcases
-.PHONY: test-binary-build-e2e
-test-binary-build-e2e:
-	#Install dependencies
-	apt-get -y install mercurial
-	cd ./tests/e2e; glide install -v
-	go test ./tests/e2e/basic -c -o $(E2E_TEST_BINARY)
+.PHONY: push
+push:
+	docker push $(IMAGE):$(VERSION)
 
 .PHONY: test-integration
 test-integration:
@@ -143,4 +102,4 @@ test-integration:
 
 .PHONY: clean
 clean:
-	rm -f armada-storage-s3fs-plugin
+rm -f ibmcloud-object-storage-plugin

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -29,19 +29,22 @@ import (
 )
 
 const (
-	optionChunkSizeMB            = "chunk-size-mb"
-	optiontlsCipherSuite         = "tls-cipher-suite"
-	optionCurlDebug              = "curl-debug"
-	optionKernelCache            = "kernel-cache"
-	optionS3FSFUSERetryCount     = "s3fs-fuse-retry-count"
-	optionStatCacheExpireSeconds = "stat-cache-expire-seconds"
-	optionObjectPath             = "object-path"
-	optionOSEndpoint             = "object-store-endpoint"
-	optionOSStorageClass         = "object-store-storage-class"
-	optionIAMEndpoint            = "iam-endpoint"
-	optionAccessKey              = "kubernetes.io/secret/access-key"
-	optionSecretKey              = "kubernetes.io/secret/secret-key"
-	optionAPIKey                 = "kubernetes.io/secret/api-key"
+	optionChunkSizeMB             = "chunk-size-mb"
+	optiontlsCipherSuite          = "tls-cipher-suite"
+	optionCurlDebug               = "curl-debug"
+	optionKernelCache             = "kernel-cache"
+	optionS3FSFUSERetryCount      = "s3fs-fuse-retry-count"
+	optionStatCacheExpireSeconds  = "stat-cache-expire-seconds"
+	optionObjectPath              = "object-path"
+	optionOSEndpoint              = "object-store-endpoint"
+	optionOSStorageClass          = "object-store-storage-class"
+	optionIAMEndpoint             = "iam-endpoint"
+	optionAccessKey               = "kubernetes.io/secret/access-key"
+	optionSecretKey               = "kubernetes.io/secret/secret-key"
+	optionAPIKey                  = "kubernetes.io/secret/api-key"
+	optionConnectTimeoutSeconds   = "connect-timeout"
+	optionReadwriteTimeoutSeconds = "readwrite-timeout"
+	optionUseXattr                = "use-xattr"
 
 	testDir            = "/tmp/"
 	testChunkSizeMB    = 500
@@ -231,14 +234,14 @@ func Test_Mount_BadS3FSFUSERetryCount(t *testing.T) {
 	}
 }
 
-func Test_Mount_S3FSFUSERetryCount_Zero(t *testing.T) {
+func Test_Mount_S3FSFUSERetryCount_Negative(t *testing.T) {
 	p := getPlugin()
 	r := getMountRequest()
-	r.Opts[optionS3FSFUSERetryCount] = "0"
+	r.Opts[optionS3FSFUSERetryCount] = "-1"
 
 	resp := p.Mount(r)
 	if assert.Equal(t, interfaces.StatusFailure, resp.Status) {
-		assert.Contains(t, resp.Message, "value of s3fs-fuse-retry-count should be non-zero")
+		assert.Contains(t, resp.Message, "value of s3fs-fuse-retry-count should be >= 1")
 	}
 }
 
@@ -701,6 +704,7 @@ func Test_Mount_fsGroup_Nogroup_Positive(t *testing.T) {
 		"-o", "mp_umask=002",
 		"-o", "instance_name=" + testDir,
 		"-o", "gid=65534",
+		"-o", "uid=65534",
 		"-o", "default_acl=",
 	}
 	resp := p.Mount(r)
@@ -881,4 +885,120 @@ func Test_Init_Positive(t *testing.T) {
 	p := getPlugin()
 	resp := p.Init()
 	assert.Equal(t, interfaces.StatusSuccess, resp.Status)
+}
+func Test_ConnectTimeoutSeconds_NonInt(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionConnectTimeoutSeconds] = "non-int-value"
+
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusFailure, resp.Status) {
+		assert.Contains(t, resp.Message, "Cannot convert value of connect-timeout-seconds into integer")
+	}
+}
+
+func Test_ConnectTimeoutSeconds_Positive(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionConnectTimeoutSeconds] = "1"
+
+	expectedArgs := []string{
+		testBucket,
+		testDir,
+		"-o", "multireq_max=" + strconv.Itoa(testMultiReqMax),
+		"-o", "cipher_suites=" + testTLSCipherSuite,
+		"-o", "use_path_request_style",
+		"-o", "passwd_file=" + path.Join(dataRootPath, fmt.Sprintf("%x", sha256.Sum256([]byte(testDir))), passwordFileName),
+		"-o", "url=" + testOSEndpoint,
+		"-o", "endpoint=" + testStorageClass,
+		"-o", "parallel_count=" + strconv.Itoa(testParallelCount),
+		"-o", "multipart_size=" + strconv.Itoa(testChunkSizeMB),
+		"-o", "dbglevel=" + testDebugLevel,
+		"-o", "max_stat_cache_size=" + strconv.Itoa(testStatCacheSize),
+		"-o", "allow_other",
+		"-o", "max_background=1000",
+		"-o", "mp_umask=002",
+		"-o", "instance_name=" + testDir,
+		"-o", "default_acl=",
+		"-o", "connect_timeout=1",
+	}
+
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
+		assert.Equal(t, expectedArgs, commandArgs)
+	}
+}
+
+func Test_ReadwriteTimeoutSeconds_NonInt(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionReadwriteTimeoutSeconds] = "non-int-value"
+
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusFailure, resp.Status) {
+		assert.Contains(t, resp.Message, "Cannot convert value of readwrite-timeout-seconds into integer")
+	}
+}
+
+func Test_ReadwriteTimeoutSeconds_Positive(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionReadwriteTimeoutSeconds] = "1"
+
+	expectedArgs := []string{
+		testBucket,
+		testDir,
+		"-o", "multireq_max=" + strconv.Itoa(testMultiReqMax),
+		"-o", "cipher_suites=" + testTLSCipherSuite,
+		"-o", "use_path_request_style",
+		"-o", "passwd_file=" + path.Join(dataRootPath, fmt.Sprintf("%x", sha256.Sum256([]byte(testDir))), passwordFileName),
+		"-o", "url=" + testOSEndpoint,
+		"-o", "endpoint=" + testStorageClass,
+		"-o", "parallel_count=" + strconv.Itoa(testParallelCount),
+		"-o", "multipart_size=" + strconv.Itoa(testChunkSizeMB),
+		"-o", "dbglevel=" + testDebugLevel,
+		"-o", "max_stat_cache_size=" + strconv.Itoa(testStatCacheSize),
+		"-o", "allow_other",
+		"-o", "max_background=1000",
+		"-o", "mp_umask=002",
+		"-o", "instance_name=" + testDir,
+		"-o", "default_acl=",
+		"-o", "readwrite_timeout=1",
+	}
+
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
+		assert.Equal(t, expectedArgs, commandArgs)
+	}
+}
+func Test_UseXattr_Positive(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionUseXattr] = "true"
+
+	expectedArgs := []string{
+		testBucket,
+		testDir,
+		"-o", "multireq_max=" + strconv.Itoa(testMultiReqMax),
+		"-o", "cipher_suites=" + testTLSCipherSuite,
+		"-o", "use_path_request_style",
+		"-o", "passwd_file=" + path.Join(dataRootPath, fmt.Sprintf("%x", sha256.Sum256([]byte(testDir))), passwordFileName),
+		"-o", "url=" + testOSEndpoint,
+		"-o", "endpoint=" + testStorageClass,
+		"-o", "parallel_count=" + strconv.Itoa(testParallelCount),
+		"-o", "multipart_size=" + strconv.Itoa(testChunkSizeMB),
+		"-o", "dbglevel=" + testDebugLevel,
+		"-o", "max_stat_cache_size=" + strconv.Itoa(testStatCacheSize),
+		"-o", "allow_other",
+		"-o", "max_background=1000",
+		"-o", "mp_umask=002",
+		"-o", "instance_name=" + testDir,
+		"-o", "default_acl=",
+		"-o", "use_xattr",
+	}
+
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
+		assert.Equal(t, expectedArgs, commandArgs)
+	}
 }

--- a/driver/interfaces/plugin.go
+++ b/driver/interfaces/plugin.go
@@ -37,7 +37,8 @@ type FlexPlugin interface {
 // CapabilitiesResponse represents a capabilities response of the init command
 type CapabilitiesResponse struct {
 	// Attach value is True/False (depending if the driver implements attach and detach)
-	Attach bool `json:"attach"`
+	Attach  bool `json:"attach"`
+	FSGroup bool `json:"fsGroup"`
 }
 
 // FlexVolumeResponse represents a response of the volume plugin

--- a/images/driver/Dockerfile.builder
+++ b/images/driver/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.10.7
+FROM golang:1.11.5
 
 # Default values
 ARG git_commit_id=unknown

--- a/images/provisioner/Dockerfile.builder
+++ b/images/provisioner/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM golang:1.10.7
+FROM golang:1.11.5
 ADD . /go/src/github.com/IBM/ibmcloud-object-storage-plugin
 RUN set -ex; cd /go/src/github.com/IBM/ibmcloud-object-storage-plugin/ && CGO_ENABLED=0 go install -v github.com/IBM/ibmcloud-object-storage-plugin/cmd/provisioner
 RUN set -ex; tar cvC / ./etc/ssl  | gzip -n > /root/ca-certs.tar.gz

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -30,43 +30,47 @@ import (
 
 // PVC annotations
 type pvcAnnotations struct {
-	AutoCreateBucket       bool   `json:"ibm.io/auto-create-bucket,string"`
-	AutoDeleteBucket       bool   `json:"ibm.io/auto-delete-bucket,string"`
-	Bucket                 string `json:"ibm.io/bucket"`
-	ObjectPath             string `json:"ibm.io/object-path,omitempty"`
-	Endpoint               string `json:"ibm.io/endpoint,omitempty"` //Will be deprecated
-	Region                 string `json:"ibm.io/region,omitempty"`   //Will be deprecated
-	SecretName             string `json:"ibm.io/secret-name"`
-	ChunkSizeMB            string `json:"ibm.io/chunk-size-mb,omitempty"`
-	ParallelCount          string `json:"ibm.io/parallel-count,omitempty"`
-	MultiReqMax            string `json:"ibm.io/multireq-max,omitempty"`
-	StatCacheSize          string `json:"ibm.io/stat-cache-size,omitempty"`
-	S3FSFUSERetryCount     string `json:"ibm.io/s3fs-fuse-retry-count,omitempty"`
-	StatCacheExpireSeconds string `json:"ibm.io/stat-cache-expire-seconds,omitempty"`
-	IAMEndpoint            string `json:"ibm.io/iam-endpoint,omitempty"`
-	ValidateBucket         string `json:"ibm.io/validate-bucket,omitempty"`
-}
-
-// PV annotations
-type pvAnnotations struct {
-	pvcAnnotations
-	SecretNamespace string `json:"ibm.io/secret-namespace"`
+	AutoCreateBucket        bool   `json:"ibm.io/auto-create-bucket,string"`
+	AutoDeleteBucket        bool   `json:"ibm.io/auto-delete-bucket,string"`
+	Bucket                  string `json:"ibm.io/bucket"`
+	ObjectPath              string `json:"ibm.io/object-path,omitempty"`
+	Endpoint                string `json:"ibm.io/endpoint,omitempty"` //Will be deprecated
+	Region                  string `json:"ibm.io/region,omitempty"`   //Will be deprecated
+	SecretName              string `json:"ibm.io/secret-name"`
+	ChunkSizeMB             string `json:"ibm.io/chunk-size-mb,omitempty"`
+	ParallelCount           string `json:"ibm.io/parallel-count,omitempty"`
+	MultiReqMax             string `json:"ibm.io/multireq-max,omitempty"`
+	StatCacheSize           string `json:"ibm.io/stat-cache-size,omitempty"`
+	S3FSFUSERetryCount      string `json:"ibm.io/s3fs-fuse-retry-count,omitempty"`
+	StatCacheExpireSeconds  string `json:"ibm.io/stat-cache-expire-seconds,omitempty"`
+	IAMEndpoint             string `json:"ibm.io/iam-endpoint,omitempty"`
+	ValidateBucket          string `json:"ibm.io/validate-bucket,omitempty"`
+	SecretNamespace         string `json:"ibm.io/secret-namespace,omitempty"`
+	ConnectTimeoutSeconds   string `json:"ibm.io/connect-timeout,omitempty"`
+	ReadwriteTimeoutSeconds string `json:"ibm.io/readwrite-timeout,omitempty"`
+	UseXattr                bool   `json:"ibm.io/use-xattr,string,omitempty"`
+	CurlDebug               bool   `json:"ibm.io/curl-debug,string,omitempty"`
+	DebugLevel              string `json:"ibm.io/debug-level,omitempty"`
 }
 
 // Storage Class options
 type scOptions struct {
-	ChunkSizeMB        int    `json:"ibm.io/chunk-size-mb,string"`
-	ParallelCount      int    `json:"ibm.io/parallel-count,string"`
-	MultiReqMax        int    `json:"ibm.io/multireq-max,string"`
-	StatCacheSize      int    `json:"ibm.io/stat-cache-size,string"`
-	TLSCipherSuite     string `json:"ibm.io/tls-cipher-suite,omitempty"`
-	DebugLevel         string `json:"ibm.io/debug-level"`
-	CurlDebug          bool   `json:"ibm.io/curl-debug,string,omitempty"`
-	KernelCache        bool   `json:"ibm.io/kernel-cache,string,omitempty"`
-	S3FSFUSERetryCount int    `json:"ibm.io/s3fs-fuse-retry-count,string,omitempty"`
-	IAMEndpoint        string `json:"ibm.io/iam-endpoint,omitempty"`
-	OSEndpoint         string `json:"ibm.io/object-store-endpoint,omitempty"`
-	OSStorageClass     string `json:"ibm.io/object-store-storage-class,omitempty"`
+	ChunkSizeMB             int    `json:"ibm.io/chunk-size-mb,string"`
+	ParallelCount           int    `json:"ibm.io/parallel-count,string"`
+	MultiReqMax             int    `json:"ibm.io/multireq-max,string"`
+	StatCacheSize           int    `json:"ibm.io/stat-cache-size,string"`
+	TLSCipherSuite          string `json:"ibm.io/tls-cipher-suite,omitempty"`
+	DebugLevel              string `json:"ibm.io/debug-level"`
+	CurlDebug               bool   `json:"ibm.io/curl-debug,string,omitempty"`
+	KernelCache             bool   `json:"ibm.io/kernel-cache,string,omitempty"`
+	S3FSFUSERetryCount      string `json:"ibm.io/s3fs-fuse-retry-count,omitempty"`
+	StatCacheExpireSeconds  string `json:"ibm.io/stat-cache-expire-seconds,omitempty"`
+	IAMEndpoint             string `json:"ibm.io/iam-endpoint,omitempty"`
+	OSEndpoint              string `json:"ibm.io/object-store-endpoint,omitempty"`
+	OSStorageClass          string `json:"ibm.io/object-store-storage-class,omitempty"`
+	ConnectTimeoutSeconds   string `json:"ibm.io/connect-timeout,omitempty"`
+	ReadwriteTimeoutSeconds string `json:"ibm.io/readwrite-timeout,omitempty"`
+	UseXattr                bool   `json:"ibm.io/use-xattr,string"`
 }
 
 const (
@@ -102,6 +106,10 @@ func (p *IBMS3fsProvisioner) getCredentials(secretName, secretNamespace string) 
 	secrets, err := p.Client.Core().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("cannot get secret %s: %v", secretName, err)
+	}
+
+	if strings.TrimSpace(string(secrets.Type)) != driverName {
+		return nil, fmt.Errorf("Wrong Secret Type.Provided secret of type %s.Expected type %s", string(secrets.Type), driverName)
 	}
 
 	var accessKey, secretKey, apiKey, serviceInstanceID string
@@ -154,6 +162,10 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		return nil, fmt.Errorf(pvcName+":"+clusterID+":cannot unmarshal storage class parameters: %v", err)
 	}
 
+	if pvc.SecretNamespace == "" {
+		pvc.SecretNamespace = options.PVC.Namespace
+	}
+
 	//Override value of EndPoint defined in storageclass
 	// EndPoint should be defined in storage class.
 	if pvc.Endpoint != "" {
@@ -186,8 +198,27 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	//Override value of s3fs-fuse-retry-count defined in storageclass
 	if pvc.S3FSFUSERetryCount != "" {
-		if sc.S3FSFUSERetryCount, err = strconv.Atoi(pvc.S3FSFUSERetryCount); err != nil {
+		sc.S3FSFUSERetryCount = pvc.S3FSFUSERetryCount
+	}
+	if sc.S3FSFUSERetryCount != "" {
+		retryCount, err := strconv.Atoi(sc.S3FSFUSERetryCount)
+		if err != nil {
 			return nil, fmt.Errorf(pvcName+":"+clusterID+":Cannot convert value of s3fs-fuse-retry-count into integer: %v", err)
+		} else if retryCount < 1 {
+			return nil, fmt.Errorf(pvcName + ":" + clusterID + ":value of s3fs-fuse-retry-count should be >= 1")
+		}
+	}
+
+	//Override value of stat-cache-expire-seconds defined in storageclass
+	if pvc.StatCacheExpireSeconds != "" {
+		sc.StatCacheExpireSeconds = pvc.StatCacheExpireSeconds
+	}
+	if sc.StatCacheExpireSeconds != "" {
+		cacheExpireSeconds, err := strconv.Atoi(sc.StatCacheExpireSeconds)
+		if err != nil {
+			return nil, fmt.Errorf(pvcName+":"+clusterID+":Cannot convert value of stat-cache-expire-seconds into integer: %v", err)
+		} else if cacheExpireSeconds < 0 {
+			return nil, fmt.Errorf(pvcName + ":" + clusterID + ":value of stat-cache-expire-seconds should be >= 0")
 		}
 	}
 
@@ -219,14 +250,20 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		}
 	}
 
-	//Check if value of stat-cache-expire-seconds parameter can be converted to integer
-	if pvc.StatCacheExpireSeconds != "" {
-		cacheExpireSeconds, err := strconv.Atoi(pvc.StatCacheExpireSeconds)
+	if pvc.ConnectTimeoutSeconds != "" {
+		_, err = strconv.Atoi(pvc.ConnectTimeoutSeconds)
 		if err != nil {
-			return nil, fmt.Errorf(pvcName+":Cannot convert value of stat-cache-expire-seconds into integer: %v", err)
-		} else if cacheExpireSeconds < 0 {
-			return nil, fmt.Errorf(pvcName + ":value of stat-cache-expire-seconds should be >= 0")
+			return nil, fmt.Errorf(pvcName+":"+clusterID+":Cannot convert value of connect-timeout-seconds into integer: %v", err)
 		}
+		sc.ConnectTimeoutSeconds = pvc.ConnectTimeoutSeconds
+	}
+
+	if pvc.ReadwriteTimeoutSeconds != "" {
+		_, err = strconv.Atoi(pvc.ReadwriteTimeoutSeconds)
+		if err != nil {
+			return nil, fmt.Errorf(pvcName+":"+clusterID+":Cannot convert value of readwrite-timeout-seconds into integer: %v", err)
+		}
+		sc.ReadwriteTimeoutSeconds = pvc.ReadwriteTimeoutSeconds
 	}
 
 	if pvc.AutoCreateBucket && pvc.ObjectPath != "" {
@@ -260,7 +297,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	//var err_msg error
 	if valBucket {
-		creds, err = p.getCredentials(pvc.SecretName, options.PVC.Namespace)
+		creds, err = p.getCredentials(pvc.SecretName, pvc.SecretNamespace)
 		if err != nil {
 			return nil, fmt.Errorf(pvcName+":"+clusterID+":cannot get credentials: %v", err)
 		}
@@ -298,30 +335,64 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		}
 	}
 
+	if pvc.UseXattr {
+		sc.UseXattr = pvc.UseXattr
+	}
+
+	if pvc.DebugLevel != "" {
+		sc.DebugLevel = pvc.DebugLevel
+	}
+
+	if pvc.CurlDebug {
+		sc.CurlDebug = pvc.CurlDebug
+	}
+
 	driverOptions, err := parser.MarshalToMap(&driver.Options{
-		ChunkSizeMB:            sc.ChunkSizeMB,
-		ParallelCount:          sc.ParallelCount,
-		MultiReqMax:            sc.MultiReqMax,
-		StatCacheSize:          sc.StatCacheSize,
-		TLSCipherSuite:         sc.TLSCipherSuite,
-		CurlDebug:              sc.CurlDebug,
-		KernelCache:            sc.KernelCache,
-		DebugLevel:             sc.DebugLevel,
-		S3FSFUSERetryCount:     strconv.Itoa(sc.S3FSFUSERetryCount),
-		StatCacheExpireSeconds: pvc.StatCacheExpireSeconds,
-		IAMEndpoint:            sc.IAMEndpoint,
-		OSEndpoint:             sc.OSEndpoint,
-		OSStorageClass:         sc.OSStorageClass,
-		Bucket:                 pvc.Bucket,
-		ObjectPath:             pvc.ObjectPath,
+		ChunkSizeMB:             sc.ChunkSizeMB,
+		ParallelCount:           sc.ParallelCount,
+		MultiReqMax:             sc.MultiReqMax,
+		StatCacheSize:           sc.StatCacheSize,
+		TLSCipherSuite:          sc.TLSCipherSuite,
+		CurlDebug:               sc.CurlDebug,
+		KernelCache:             sc.KernelCache,
+		DebugLevel:              sc.DebugLevel,
+		S3FSFUSERetryCount:      sc.S3FSFUSERetryCount,
+		StatCacheExpireSeconds:  sc.StatCacheExpireSeconds,
+		IAMEndpoint:             sc.IAMEndpoint,
+		OSEndpoint:              sc.OSEndpoint,
+		OSStorageClass:          sc.OSStorageClass,
+		Bucket:                  pvc.Bucket,
+		ObjectPath:              pvc.ObjectPath,
+		ReadwriteTimeoutSeconds: sc.ReadwriteTimeoutSeconds,
+		ConnectTimeoutSeconds:   sc.ConnectTimeoutSeconds,
+		UseXattr:                sc.UseXattr,
 	})
 	if err != nil {
 		return nil, fmt.Errorf(pvcName+":"+clusterID+":cannot marshal driver options: %v", err)
 	}
 
-	pvAnnots, err := parser.MarshalToMap(&pvAnnotations{
-		pvcAnnotations:  pvc,
-		SecretNamespace: options.PVC.Namespace,
+	pvcAnnots, err := parser.MarshalToMap(&pvcAnnotations{
+		AutoCreateBucket:        pvc.AutoCreateBucket,
+		AutoDeleteBucket:        pvc.AutoDeleteBucket,
+		Bucket:                  pvc.Bucket,
+		ObjectPath:              pvc.ObjectPath,
+		Endpoint:                pvc.Endpoint,
+		Region:                  pvc.Region,
+		SecretName:              pvc.SecretName,
+		ChunkSizeMB:             pvc.ChunkSizeMB,
+		ParallelCount:           pvc.ParallelCount,
+		MultiReqMax:             pvc.MultiReqMax,
+		StatCacheSize:           pvc.StatCacheSize,
+		S3FSFUSERetryCount:      pvc.S3FSFUSERetryCount,
+		StatCacheExpireSeconds:  pvc.StatCacheExpireSeconds,
+		IAMEndpoint:             pvc.IAMEndpoint,
+		ValidateBucket:          pvc.ValidateBucket,
+		SecretNamespace:         pvc.SecretNamespace,
+		ReadwriteTimeoutSeconds: pvc.ReadwriteTimeoutSeconds,
+		ConnectTimeoutSeconds:   pvc.ConnectTimeoutSeconds,
+		UseXattr:                pvc.UseXattr,
+		CurlDebug:               pvc.CurlDebug,
+		DebugLevel:              pvc.DebugLevel,
 	})
 	if err != nil {
 		return nil, fmt.Errorf(pvcName+":"+clusterID+":cannot marshal pv options: %v", err)
@@ -330,7 +401,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	return &v1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        options.PVName,
-			Annotations: pvAnnots,
+			Annotations: pvcAnnots,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
@@ -342,7 +413,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 				FlexVolume: &v1.FlexPersistentVolumeSource{
 					Driver:    driverName,
 					FSType:    fsType,
-					SecretRef: &v1.SecretReference{Name: pvc.SecretName},
+					SecretRef: &v1.SecretReference{Name: pvc.SecretName, Namespace: pvc.SecretNamespace},
 					ReadOnly:  false,
 					Options:   driverOptions,
 				},
@@ -353,7 +424,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 // Delete deletes a persistent volume
 func (p *IBMS3fsProvisioner) Delete(pv *v1.PersistentVolume) error {
-	var pvAnnots pvAnnotations
+	var pvcAnnots pvcAnnotations
 
 	contextLogger, _ := logger.GetZapDefaultContextLogger()
 	contextLogger.Info("Deleting the pvc..")
@@ -362,13 +433,13 @@ func (p *IBMS3fsProvisioner) Delete(pv *v1.PersistentVolume) error {
 	regionValue := pv.Spec.PersistentVolumeSource.FlexVolume.Options["object-store-storage-class"]
 	iamEndpoint := pv.Spec.PersistentVolumeSource.FlexVolume.Options["iam-endpoint"]
 
-	err := parser.UnmarshalMap(&pv.Annotations, &pvAnnots)
+	err := parser.UnmarshalMap(&pv.Annotations, &pvcAnnots)
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal PV annotations: %v", err)
 	}
 
-	if pvAnnots.AutoDeleteBucket {
-		err = p.deleteBucket(&pvAnnots, endpointValue, regionValue, iamEndpoint)
+	if pvcAnnots.AutoDeleteBucket {
+		err = p.deleteBucket(&pvcAnnots, endpointValue, regionValue, iamEndpoint)
 		if err != nil {
 			return fmt.Errorf("cannot delete bucket: %v", err)
 		}
@@ -377,13 +448,13 @@ func (p *IBMS3fsProvisioner) Delete(pv *v1.PersistentVolume) error {
 	return nil
 }
 
-func (p *IBMS3fsProvisioner) deleteBucket(pvAnnots *pvAnnotations, endpointValue, regionValue, iamEndpoint string) error {
-	creds, err := p.getCredentials(pvAnnots.SecretName, pvAnnots.SecretNamespace)
+func (p *IBMS3fsProvisioner) deleteBucket(pvcAnnots *pvcAnnotations, endpointValue, regionValue, iamEndpoint string) error {
+	creds, err := p.getCredentials(pvcAnnots.SecretName, pvcAnnots.SecretNamespace)
 	if err != nil {
 		return fmt.Errorf("cannot get credentials: %v", err)
 	}
 	creds.IAMEndpoint = iamEndpoint
 	sess := p.Backend.NewObjectStorageSession(endpointValue, regionValue, creds, p.Logger)
 
-	return sess.DeleteBucket(pvAnnots.Bucket)
+	return sess.DeleteBucket(pvcAnnots.Bucket)
 }

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -42,57 +42,66 @@ const (
 	testOSEndpoint        = "https://test-object-store-endpoint"
 	testIAMEndpoint       = "https://test-iam-endpoint"
 
-	testChunkSizeMB        = 2
-	testParallelCount      = 3
-	testMultiReqMax        = 4
-	testStatCacheSize      = 5
-	testS3FSFUSERetryCount = 1
-	testDebugLevel         = "debug"
-	testCurlDebug          = "false"
-	testTLSCipherSuite     = "test-tls-cipher-suite"
-	testStorageClass       = "test-storage-class"
-	testObjectPath         = "/test/object-path"
+	testChunkSizeMB            = 2
+	testParallelCount          = 3
+	testMultiReqMax            = 4
+	testStatCacheSize          = 5
+	testS3FSFUSERetryCount     = 1
+	testStatCacheExpireSeconds = 1
+	testDebugLevel             = "debug"
+	testCurlDebug              = "false"
+	testTLSCipherSuite         = "test-tls-cipher-suite"
+	testStorageClass           = "test-storage-class"
+	testObjectPath             = "/test/object-path"
+	testValidateBucket         = "yes"
 
-	annotationBucket                 = "ibm.io/bucket"
-	annotationObjectPath             = "ibm.io/object-path"
-	annotationAutoCreateBucket       = "ibm.io/auto-create-bucket"
-	annotationAutoDeleteBucket       = "ibm.io/auto-delete-bucket"
-	annotationEndpoint               = "ibm.io/endpoint"
-	annotationRegion                 = "ibm.io/region"
-	annotationIAMEndpoint            = "ibm.io/iam-endpoint"
-	annotationSecretName             = "ibm.io/secret-name"
-	annotationSecretNamespace        = "ibm.io/secret-namespace"
-	annotationStatCacheExpireSeconds = "ibm.io/stat-cache-expire-seconds"
+	annotationBucket                  = "ibm.io/bucket"
+	annotationObjectPath              = "ibm.io/object-path"
+	annotationAutoCreateBucket        = "ibm.io/auto-create-bucket"
+	annotationAutoDeleteBucket        = "ibm.io/auto-delete-bucket"
+	annotationEndpoint                = "ibm.io/endpoint"
+	annotationRegion                  = "ibm.io/region"
+	annotationIAMEndpoint             = "ibm.io/iam-endpoint"
+	annotationSecretName              = "ibm.io/secret-name"
+	annotationSecretNamespace         = "ibm.io/secret-namespace"
+	annotationStatCacheExpireSeconds  = "ibm.io/stat-cache-expire-seconds"
+	annotationValidateBucket          = "ibm.io/validate-bucket"
+	annotationConnectTimeoutSeconds   = "ibm.io/connect-timeout"
+	annotationReadwriteTimeoutSeconds = "ibm.io/readwrite-timeout"
 
-	parameterChunkSizeMB        = "ibm.io/chunk-size-mb"
-	parameterParallelCount      = "ibm.io/parallel-count"
-	parameterMultiReqMax        = "ibm.io/multireq-max"
-	parameterStatCacheSize      = "ibm.io/stat-cache-size"
-	parameterS3FSFUSERetryCount = "ibm.io/s3fs-fuse-retry-count"
-	parameterTLSCipherSuite     = "ibm.io/tls-cipher-suite"
-	parameterDebugLevel         = "ibm.io/debug-level"
-	parameterCurlDebug          = "ibm.io/curl-debug"
-	parameterKernelCache        = "ibm.io/kernel-cache"
-	parameterOSEndpoint         = "ibm.io/object-store-endpoint"
-	parameterIAMEndpoint        = "ibm.io/iam-endpoint"
-	parameterStorageClass       = "ibm.io/object-store-storage-class"
+	parameterChunkSizeMB            = "ibm.io/chunk-size-mb"
+	parameterParallelCount          = "ibm.io/parallel-count"
+	parameterMultiReqMax            = "ibm.io/multireq-max"
+	parameterStatCacheSize          = "ibm.io/stat-cache-size"
+	parameterS3FSFUSERetryCount     = "ibm.io/s3fs-fuse-retry-count"
+	parameterTLSCipherSuite         = "ibm.io/tls-cipher-suite"
+	parameterDebugLevel             = "ibm.io/debug-level"
+	parameterCurlDebug              = "ibm.io/curl-debug"
+	parameterKernelCache            = "ibm.io/kernel-cache"
+	parameterOSEndpoint             = "ibm.io/object-store-endpoint"
+	parameterIAMEndpoint            = "ibm.io/iam-endpoint"
+	parameterStorageClass           = "ibm.io/object-store-storage-class"
+	parameterStatCacheExpireSeconds = "ibm.io/stat-cache-expire-seconds"
 
-	optionChunkSizeMB            = "chunk-size-mb"
-	optionParallelCount          = "parallel-count"
-	optionMultiReqMax            = "multireq-max"
-	optionStatCacheSize          = "stat-cache-size"
-	optionS3FSFUSERetryCount     = "s3fs-fuse-retry-count"
-	optionTLSCipherSuite         = "tls-cipher-suite"
-	optionDebugLevel             = "debug-level"
-	optionCurlDebug              = "curl-debug"
-	optionKernelCache            = "kernel-cache"
-	optionOSEndpoint             = "object-store-endpoint"
-	optionRegion                 = "region"
-	optionBucket                 = "bucket"
-	optionStatCacheExpireSeconds = "stat-cache-expire-seconds"
-	optionObjectPath             = "object-path"
-	optionStorageClass           = "object-store-storage-class"
-	optionIAMEndpoint            = "iam-endpoint"
+	optionChunkSizeMB             = "chunk-size-mb"
+	optionParallelCount           = "parallel-count"
+	optionMultiReqMax             = "multireq-max"
+	optionStatCacheSize           = "stat-cache-size"
+	optionS3FSFUSERetryCount      = "s3fs-fuse-retry-count"
+	optionTLSCipherSuite          = "tls-cipher-suite"
+	optionDebugLevel              = "debug-level"
+	optionCurlDebug               = "curl-debug"
+	optionKernelCache             = "kernel-cache"
+	optionOSEndpoint              = "object-store-endpoint"
+	optionRegion                  = "region"
+	optionBucket                  = "bucket"
+	optionStatCacheExpireSeconds  = "stat-cache-expire-seconds"
+	optionObjectPath              = "object-path"
+	optionStorageClass            = "object-store-storage-class"
+	optionIAMEndpoint             = "iam-endpoint"
+	optionReadwriteTimeoutSeconds = "readwrite-timeout"
+	optionConnectTimeoutSeconds   = "connect-timeout"
+	optionUseXattr                = "use-xattr"
 )
 
 type clientGoConfig struct {
@@ -101,17 +110,24 @@ type clientGoConfig struct {
 	missingSecretKey      bool
 	withAPIKey            bool
 	withServiceInstanceID bool
+	wrongSecretType       bool
 }
 
 func getFakeClientGo(cfg *clientGoConfig) kubernetes.Interface {
 	objects := []runtime.Object{}
+	var secret *v1.Secret
 	if !cfg.missingSecret {
-		secret := &v1.Secret{
+		secret = &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      testSecretName,
 				Namespace: testNamespace,
 			},
 			Data: make(map[string][]byte),
+		}
+		if cfg.wrongSecretType {
+			secret.Type = "test-type"
+		} else {
+			secret.Type = "ibm/ibmc-s3fs"
 		}
 
 		if cfg.withAPIKey {
@@ -188,16 +204,17 @@ func getVolumeOptions() controller.VolumeOptions {
 			},
 		},
 		Parameters: map[string]string{
-			parameterChunkSizeMB:        strconv.Itoa(testChunkSizeMB),
-			parameterParallelCount:      strconv.Itoa(testParallelCount),
-			parameterMultiReqMax:        strconv.Itoa(testMultiReqMax),
-			parameterStatCacheSize:      strconv.Itoa(testStatCacheSize),
-			parameterS3FSFUSERetryCount: strconv.Itoa(testS3FSFUSERetryCount),
-			parameterTLSCipherSuite:     testTLSCipherSuite,
-			parameterDebugLevel:         testDebugLevel,
-			parameterStorageClass:       testStorageClass,
-			parameterOSEndpoint:         testOSEndpoint,
-			parameterIAMEndpoint:        testIAMEndpoint,
+			parameterChunkSizeMB:            strconv.Itoa(testChunkSizeMB),
+			parameterParallelCount:          strconv.Itoa(testParallelCount),
+			parameterMultiReqMax:            strconv.Itoa(testMultiReqMax),
+			parameterStatCacheSize:          strconv.Itoa(testStatCacheSize),
+			parameterS3FSFUSERetryCount:     strconv.Itoa(testS3FSFUSERetryCount),
+			parameterStatCacheExpireSeconds: strconv.Itoa(testStatCacheExpireSeconds),
+			parameterTLSCipherSuite:         testTLSCipherSuite,
+			parameterDebugLevel:             testDebugLevel,
+			parameterStorageClass:           testStorageClass,
+			parameterOSEndpoint:             testOSEndpoint,
+			parameterIAMEndpoint:            testIAMEndpoint,
 		},
 	}
 
@@ -426,6 +443,17 @@ func Test_Provision_PVCAnnotations_BadS3FSFUSERetryCount(t *testing.T) {
 	}
 }
 
+func Test_Provision_PVCAnnotations_S3FSFUSERetryCount_Negative(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations["ibm.io/s3fs-fuse-retry-count"] = "-1"
+
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "value of s3fs-fuse-retry-count should be >= 1")
+	}
+}
+
 func Test_Provision_PVCAnnotations_S3FSFUSERetryCount_Positive(t *testing.T) {
 	p := getProvisioner()
 	v := getVolumeOptions()
@@ -605,18 +633,19 @@ func Test_Provision_Positive(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t,
 		map[string]string{
-			optionChunkSizeMB:        strconv.Itoa(testChunkSizeMB),
-			optionParallelCount:      strconv.Itoa(testParallelCount),
-			optionMultiReqMax:        strconv.Itoa(testMultiReqMax),
-			optionStatCacheSize:      strconv.Itoa(testStatCacheSize),
-			optionS3FSFUSERetryCount: strconv.Itoa(testS3FSFUSERetryCount),
-			optionTLSCipherSuite:     testTLSCipherSuite,
-			optionDebugLevel:         testDebugLevel,
-			optionCurlDebug:          testCurlDebug,
-			optionOSEndpoint:         testOSEndpoint,
-			optionBucket:             testBucket,
-			optionStorageClass:       testStorageClass,
-			optionIAMEndpoint:        testIAMEndpoint,
+			optionChunkSizeMB:            strconv.Itoa(testChunkSizeMB),
+			optionParallelCount:          strconv.Itoa(testParallelCount),
+			optionMultiReqMax:            strconv.Itoa(testMultiReqMax),
+			optionStatCacheSize:          strconv.Itoa(testStatCacheSize),
+			optionS3FSFUSERetryCount:     strconv.Itoa(testS3FSFUSERetryCount),
+			optionStatCacheExpireSeconds: strconv.Itoa(testStatCacheExpireSeconds),
+			optionTLSCipherSuite:         testTLSCipherSuite,
+			optionDebugLevel:             testDebugLevel,
+			optionCurlDebug:              testCurlDebug,
+			optionOSEndpoint:             testOSEndpoint,
+			optionBucket:                 testBucket,
+			optionStorageClass:           testStorageClass,
+			optionIAMEndpoint:            testIAMEndpoint,
 		},
 		pv.Spec.FlexVolume.Options,
 	)
@@ -774,4 +803,100 @@ func Test_Provision_Delete_IAM_Positive(t *testing.T) {
 	assert.Equal(t, testAPIKey, factory.LastCredentials.APIKey)
 	assert.Equal(t, testIAMEndpoint, factory.LastCredentials.IAMEndpoint)
 	assert.Equal(t, bucketName, factory.LastDeletedBucket)
+}
+
+func Test_Provision_DifferentSecretNS(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Namespace = "pvc-namespace"
+	v.PVC.Annotations[annotationSecretNamespace] = testNamespace
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, testNamespace, pv.Annotations[annotationSecretNamespace])
+}
+
+func Test_Validate_Bucket_True(t *testing.T) {
+	p := getFakeBackendProvisioner(&fake.ObjectStorageSessionFactory{FailCheckBucketAccess: true})
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationValidateBucket] = testValidateBucket
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "cannot access bucket")
+	}
+}
+
+func Test_Wrong_Secret_Type_True(t *testing.T) {
+	p := getFakeClientGoProvisioner(&clientGoConfig{wrongSecretType: true})
+	v := getVolumeOptions()
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Wrong Secret Type")
+	}
+}
+func Test_Provision_PVCAnnotations_ReadwriteTimeoutSeconds_NonInt(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationReadwriteTimeoutSeconds] = "non-int-value"
+
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Cannot convert value of readwrite-timeout-seconds into integer")
+	}
+}
+
+func Test_Provision_PVCAnnotations_ConnectTimeoutSeconds_NonInt(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationConnectTimeoutSeconds] = "non-int-value"
+
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "Cannot convert value of connect-timeout-seconds into integer")
+	}
+}
+
+func Test_Provision_PVCAnnotations_ReadwriteTimeoutSeconds_Positive(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationReadwriteTimeoutSeconds] = "6"
+
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "6", pv.Spec.FlexVolume.Options[optionReadwriteTimeoutSeconds])
+}
+
+func Test_Provision_PVCAnnotations_ConnectTimeoutSeconds_Positive(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationConnectTimeoutSeconds] = "6"
+
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "6", pv.Spec.FlexVolume.Options[optionConnectTimeoutSeconds])
+}
+func Test_Provision_PVCAnnotations_UseXattr(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations["ibm.io/use-xattr"] = "true"
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "true", pv.Spec.FlexVolume.Options[optionUseXattr])
+}
+
+func Test_Provision_PVCAnnotations_DebugLevel(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations["ibm.io/debug-level"] = "info"
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "info", pv.Spec.FlexVolume.Options[optionDebugLevel])
+}
+
+func Test_Provision_PVCAnnotations_CurlDebug(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations["ibm.io/curl-debug"] = "true"
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "true", pv.Spec.FlexVolume.Options[optionCurlDebug])
 }


### PR DESCRIPTION
What this PR does / why we need it:
This PR is to support following features
- Use fsGroup as both owner and group ID for Volume
- Set the FSGroup capability to false in driver code
- go lang version change and secret type issue fix
- Add connect_timeout and readwrite_timeout parameters in SC
- Add ibm.io/debug-level: "debug" ibm.io/curl-debug: "true" and use_xattr options in pvc
- Add parameter 'stat-cache-expire-seconds' in StorageClass
- Secret and PVC can be in different namespace


Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

Special notes for your reviewer:
Tested with K8S cluster deployed in IBM Cloud Kubernetes Service