### PR TITLE
Allow mounting bucket as per AccessMode defined in PVC

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -83,6 +83,7 @@ type Options struct {
 	OSEndpoint             string `json:"object-store-endpoint,omitempty"`
 	OSStorageClass         string `json:"object-store-storage-class,omitempty"`
 	IAMEndpoint            string `json:"iam-endpoint,omitempty"`
+	AccessMode             string `json: access-mode,omitempty`
 }
 
 // PathExists returns true if the specified path exists.
@@ -532,6 +533,11 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 		if options.FSGroup == "65534" {
 			args = append(args, "-o", "gid="+options.FSGroup)
 		}
+	}
+
+	// Check if AccessMode is ReadOnlyMany
+	if options.AccessMode == "ReadOnlyMany" {
+		args = append(args, "-o", "ro")
 	}
 
 	//Number of retries for failed S3 transaction

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -83,7 +83,7 @@ type Options struct {
 	OSEndpoint             string `json:"object-store-endpoint,omitempty"`
 	OSStorageClass         string `json:"object-store-storage-class,omitempty"`
 	IAMEndpoint            string `json:"iam-endpoint,omitempty"`
-	AccessMode             string `json: access-mode,omitempty`
+	AccessMode             string `json:"access-mode,omitempty"`
 }
 
 // PathExists returns true if the specified path exists.

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -86,7 +86,7 @@ type Options struct {
 	ConnectTimeoutSeconds   string `json:"connect-timeout,omitempty"`
 	ReadwriteTimeoutSeconds string `json:"readwrite-timeout,omitempty"`
 	UseXattr                bool   `json:"use-xattr,string,omitempty"`
-  AccessMode              string `json:"access-mode,omitempty"`
+	AccessMode              string `json:"access-mode,omitempty"`
 }
 
 // PathExists returns true if the specified path exists.

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -709,6 +709,36 @@ func Test_Mount_fsGroup_Nogroup_Positive(t *testing.T) {
 	}
 }
 
+func Test_Mount_ReadOnly_Positive(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts["access-mode"] = "ReadOnlyMany"
+	expectedArgs := []string{
+		testBucket,
+		testDir,
+		"-o", "multireq_max=" + strconv.Itoa(testMultiReqMax),
+		"-o", "cipher_suites=" + testTLSCipherSuite,
+		"-o", "use_path_request_style",
+		"-o", "passwd_file=" + path.Join(dataRootPath, fmt.Sprintf("%x", sha256.Sum256([]byte(testDir))), passwordFileName),
+		"-o", "url=" + testOSEndpoint,
+		"-o", "endpoint=" + testStorageClass,
+		"-o", "parallel_count=" + strconv.Itoa(testParallelCount),
+		"-o", "multipart_size=" + strconv.Itoa(testChunkSizeMB),
+		"-o", "dbglevel=" + testDebugLevel,
+		"-o", "max_stat_cache_size=" + strconv.Itoa(testStatCacheSize),
+		"-o", "allow_other",
+		"-o", "max_background=1000",
+		"-o", "mp_umask=002",
+		"-o", "instance_name=" + testDir,
+		"-o", "ro",
+		"-o", "default_acl=",
+	}
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
+		assert.Equal(t, expectedArgs, commandArgs)
+	}
+}
+
 func Test_Mount_DummyOSStorageClass_Positive(t *testing.T) {
 	p := getPlugin()
 	r := getMountRequest()

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -346,8 +346,8 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 	if pvc.CurlDebug {
 		sc.CurlDebug = pvc.CurlDebug
 	}
-  
-  // Check AccessMode
+
+	// Check AccessMode
 	accessMode := options.PVC.Spec.AccessModes
 	contextLogger.Info(pvcName+":"+clusterID+": acccess mode is.. ", zap.Any("access mode", accessMode))
 	if len(accessMode) > 1 {
@@ -373,7 +373,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		ReadwriteTimeoutSeconds: sc.ReadwriteTimeoutSeconds,
 		ConnectTimeoutSeconds:   sc.ConnectTimeoutSeconds,
 		UseXattr:                sc.UseXattr,
-    AccessMode:              string(accessMode[0]),
+		AccessMode:              string(accessMode[0]),
 	})
 	if err != nil {
 		return nil, fmt.Errorf(pvcName+":"+clusterID+":cannot marshal driver options: %v", err)

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -298,6 +298,13 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		}
 	}
 
+	// Check AccessMode
+	accessMode := options.PVC.Spec.AccessModes
+	contextLogger.Info(pvcName+":"+clusterID+": acccess mode is.. ", zap.Any("access mode", accessMode))
+	if len(accessMode) > 1 {
+		return nil, fmt.Errorf(pvcName + ":" + clusterID + ": More that one access mode is not supported.")
+	}
+
 	driverOptions, err := parser.MarshalToMap(&driver.Options{
 		ChunkSizeMB:            sc.ChunkSizeMB,
 		ParallelCount:          sc.ParallelCount,
@@ -314,6 +321,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		OSStorageClass:         sc.OSStorageClass,
 		Bucket:                 pvc.Bucket,
 		ObjectPath:             pvc.ObjectPath,
+		AccessMode:             string(accessMode[0]),
 	})
 	if err != nil {
 		return nil, fmt.Errorf(pvcName+":"+clusterID+":cannot marshal driver options: %v", err)

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -621,6 +621,7 @@ func Test_Provision_Positive(t *testing.T) {
 			optionBucket:             testBucket,
 			optionStorageClass:       testStorageClass,
 			optionIAMEndpoint:        testIAMEndpoint,
+			optionAccessMode:         "ReadWriteMany",
 		},
 		pv.Spec.FlexVolume.Options,
 	)
@@ -663,7 +664,7 @@ func Test_Provision_AccessMode_ReadWrite_Positive(t *testing.T) {
 
 	pv, err := p.Provision(v)
 	assert.NoError(t, err)
-	assert.Equal(t, "ReadWriteMany", pv.Spec.FlexVolume.Options.AccessMode)
+	assert.Equal(t, "ReadWriteMany", pv.Spec.FlexVolume.Options[optionAccessMode])
 }
 
 func Test_Provision_AccessMode_ReadOnly_Positive(t *testing.T) {
@@ -673,7 +674,7 @@ func Test_Provision_AccessMode_ReadOnly_Positive(t *testing.T) {
 
 	pv, err := p.Provision(v)
 	assert.NoError(t, err)
-	assert.Equal(t, "ReadOnlyMany", pv.Spec.FlexVolume.Options.AccessMode)
+	assert.Equal(t, "ReadOnlyMany", pv.Spec.FlexVolume.Options[optionAccessMode])
 }
 
 func Test_Provision_AutoBucketCreate_Positive(t *testing.T) {

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -93,6 +93,7 @@ const (
 	optionObjectPath             = "object-path"
 	optionStorageClass           = "object-store-storage-class"
 	optionIAMEndpoint            = "iam-endpoint"
+	optionAccessMode             = "access-mode"
 )
 
 type clientGoConfig struct {
@@ -185,6 +186,9 @@ func getVolumeOptions() controller.VolumeOptions {
 					annotationSecretName: testSecretName,
 				},
 				Namespace: testNamespace,
+			},
+			Spec: v1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteMany},
 			},
 		},
 		Parameters: map[string]string{
@@ -640,6 +644,36 @@ func Test_Provision_KernelCache_Positive(t *testing.T) {
 	pv, err := p.Provision(v)
 	assert.NoError(t, err)
 	assert.Equal(t, "true", pv.Spec.FlexVolume.Options[optionKernelCache])
+}
+
+func Test_Provision_AccessMode_Negative(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany, v1.ReadWriteOnce}
+
+	_, err := p.Provision(v)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "More that one access mode is not supported")
+	}
+}
+
+func Test_Provision_AccessMode_ReadWrite_Positive(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "ReadWriteMany", pv.Spec.FlexVolume.Options.AccessMode)
+}
+
+func Test_Provision_AccessMode_ReadOnly_Positive(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Spec.AccessModes = []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany}
+
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "ReadOnlyMany", pv.Spec.FlexVolume.Options.AccessMode)
 }
 
 func Test_Provision_AutoBucketCreate_Positive(t *testing.T) {

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -102,7 +102,7 @@ const (
 	optionReadwriteTimeoutSeconds = "readwrite-timeout"
 	optionConnectTimeoutSeconds   = "connect-timeout"
 	optionUseXattr                = "use-xattr"
-	optionAccessMode             = "access-mode"
+	optionAccessMode              = "access-mode"
 )
 
 type clientGoConfig struct {

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -102,7 +102,7 @@ const (
 	optionReadwriteTimeoutSeconds = "readwrite-timeout"
 	optionConnectTimeoutSeconds   = "connect-timeout"
 	optionUseXattr                = "use-xattr"
-  optionAccessMode             = "access-mode"
+	optionAccessMode             = "access-mode"
 )
 
 type clientGoConfig struct {
@@ -650,7 +650,7 @@ func Test_Provision_Positive(t *testing.T) {
 			optionBucket:                 testBucket,
 			optionStorageClass:           testStorageClass,
 			optionIAMEndpoint:            testIAMEndpoint,
-      optionAccessMode:             "ReadWriteMany",
+			optionAccessMode:             "ReadWriteMany",
 		},
 		pv.Spec.FlexVolume.Options,
 	)


### PR DESCRIPTION
What this PR does / why we need it:
**This PR is to allow mounting bucket as per accessMode defined in PVC spec.
The accessMode specified in PVC will be passed as driver Options to flexVolume driver code and if accessMode is `ReadOnlyMany`, then bucket will be mounted as `ReadOnly`, else bucket will be mounted as `ReadWrite`.** 

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

Special notes for your reviewer:
Tested with K8S cluster deployed in IBM Cloud Kubernetes Service