### PR TITLE
Option to pass TLSCipherSuite from PVC

### DIFF
--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -51,6 +51,7 @@ type pvcAnnotations struct {
 	UseXattr                bool   `json:"ibm.io/use-xattr,string,omitempty"`
 	CurlDebug               bool   `json:"ibm.io/curl-debug,string,omitempty"`
 	DebugLevel              string `json:"ibm.io/debug-level,omitempty"`
+	TLSCipherSuite          string `json:"ibm.io/tls-cipher-suite,omitempty"`
 }
 
 // Storage Class options
@@ -345,6 +346,10 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	if pvc.CurlDebug {
 		sc.CurlDebug = pvc.CurlDebug
+	}
+
+	if pvc.TLSCipherSuite != "" {
+		sc.TLSCipherSuite = pvc.TLSCipherSuite
 	}
 
 	// Check AccessMode

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -935,3 +935,12 @@ func Test_Provision_PVCAnnotations_CurlDebug(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "true", pv.Spec.FlexVolume.Options[optionCurlDebug])
 }
+
+func Test_Provision_PVCAnnotations_TLS(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations["ibm.io/tls-cipher-suite"] = "AESGCM"
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "AESGCM", pv.Spec.FlexVolume.Options[optionTLSCipherSuite])
+}


### PR DESCRIPTION
What this PR does / why we need it:
This PR adds feature to pass `TLSCipherSuite` from pvc yaml file

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

Special notes for your reviewer:
Tested with K8S cluster deployed in IBM Cloud Kubernetes Service