### PR TITLE
fail POD creation if s3fs process terminates immediately

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
 
 const (
@@ -634,6 +635,19 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 		p.Logger.Error(podUID+":"+"Running s3fs",
 			zap.String("Error", string(out)))
 		return fmt.Errorf("s3fs mount failed: %s", string(out))
+	}
+
+	// Wait for 1 second before checking whether s3fs process really terminated
+	time.Sleep(1 * time.Second)
+	// Check whether s3fs process terminated
+	cmd := "ps aux | grep " + podUID + " | grep s3fs | grep -v grep"
+	output, err = command("bash", "-c", cmd).CombinedOutput()
+	if err == nil {
+		s3fsProcStatus := strings.SplitAfterN(string(output), "\n", 2)
+		if s3fsProcStatus[1] == "" {
+			p.Logger.Error(podUID+":"+"s3fs process terminated.")
+			return fmt.Errorf("s3fs mount failed: s3fs process terminated.")
+		}
 	}
 
 	fInfo, err = os.Lstat(mountRequest.MountDir)


### PR DESCRIPTION
What this PR does / why we need it:
**This PR is to error out POD creation where s3fs process for that POD terminates immediately when there is something wrong with s3fs parameters passed to s3fs-fuse.**

Which issue(s) this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

Special notes for your reviewer:
Tested with K8S cluster deployed in IBM Cloud Kubernetes Service(IKS).