### PR TITLE
Removed a space before the spec to fix the indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,12 +225,12 @@ EOF
        ibm.io/stat-cache-expire-seconds: ""   # stat-cache-expire time in seconds; default is no expire.
        ibm.io/cos-service: <COS SERVICE NAME>
        ibm.io/cos-service-ns: <NAMESPACE WHERE COS SERVICE IS CREATED>
-    spec:
-      accessModes:
-        - ReadWriteOnce
-      resources:
-        requests:
-          storage: 8Gi # fictitious value
+   spec:
+     accessModes:
+       - ReadWriteOnce
+     resources:
+       requests:
+         storage: 8Gi # fictitious value
 
   ```
 ## Uninstall


### PR DESCRIPTION
Removed a space before the spec to fix the following error:

 error converting YAML to JSON: yaml: line 16: did not find expected key