### PR TITLE
Support new parameter for fsgroup from k1.15 onwards

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -69,6 +69,7 @@ type Options struct {
 	MultiReqMax             int    `json:"multireq-max,string"`
 	StatCacheSize           int    `json:"stat-cache-size,string"`
 	FSGroup                 string `json:"kubernetes.io/fsGroup,omitempty"`
+	FSGroupNew              string `json:"kubernetes.io/mounterArgs.FsGroup,omitempty"`
 	Endpoint                string `json:"endpoint,omitempty"` //Will be deprecated
 	Region                  string `json:"region,omitempty"`   //Will be deprecated
 	Bucket                  string `json:"bucket"`
@@ -598,6 +599,9 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 	if _, ok := mountRequest.Opts["kubernetes.io/fsGroup"]; ok {
 		args = append(args, "-o", "gid="+options.FSGroup)
 		args = append(args, "-o", "uid="+options.FSGroup)
+	} else if _, ok := mountRequest.Opts["kubernetes.io/mounterArgs.FsGroup"]; ok {
+		args = append(args, "-o", "gid="+options.FSGroupNew)
+		args = append(args, "-o", "uid="+options.FSGroupNew)
 	}
 
 	// Check if AccessMode is ReadOnlyMany

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -1092,3 +1092,34 @@ func Test_Mount_ServiceNamePositive(t *testing.T) {
 		assert.Equal(t, expectedArgs, commandArgs)
 	}
 }
+
+func Test_Mount_fsGroupNew_Nogroup_Positive(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts["kubernetes.io/mounterArgs.FsGroup"] = "65534"
+	expectedArgs := []string{
+		testBucket,
+		testDir,
+		"-o", "multireq_max=" + strconv.Itoa(testMultiReqMax),
+		"-o", "cipher_suites=" + testTLSCipherSuite,
+		"-o", "use_path_request_style",
+		"-o", "passwd_file=" + path.Join(dataRootPath, fmt.Sprintf("%x", sha256.Sum256([]byte(testDir))), passwordFileName),
+		"-o", "url=" + testOSEndpoint,
+		"-o", "endpoint=" + testStorageClass,
+		"-o", "parallel_count=" + strconv.Itoa(testParallelCount),
+		"-o", "multipart_size=" + strconv.Itoa(testChunkSizeMB),
+		"-o", "dbglevel=" + testDebugLevel,
+		"-o", "max_stat_cache_size=" + strconv.Itoa(testStatCacheSize),
+		"-o", "allow_other",
+		"-o", "max_background=1000",
+		"-o", "mp_umask=002",
+		"-o", "instance_name=" + testDir,
+		"-o", "gid=65534",
+		"-o", "uid=65534",
+		"-o", "default_acl=private",
+	}
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
+		assert.Equal(t, expectedArgs, commandArgs)
+	}
+}


### PR DESCRIPTION
Because of change in mount request Opts parameter key the fsGroup ID is not getting applied to COS Volume

`"kubernetes.io/fsGroup": "1001" -> "kubernetes.io/mounterArgs.FsGroup": "1001"`

`K1.15`

```
ambikas-mbp-2:deploy ambikanair$ kubectl exec -it pod-diff   sh
$ ls -al /mnt/s3fs/bdmixdata/
total 50331651
drwxr-xr-x 1 root root           0 Nov 28 04:57 .
drwxrwxr-x 1 root root           0 Jan  1  1970 ..
-rw-r--r-- 1 1000 root           3 Nov 28 08:34 new.txt
-rw-r--r-- 1 root root 17179869184 Nov 28 04:59 test02-016G
-rw-r--r-- 1 root root 34359738368 Nov 28 05:03 test02-032G
$ 
```
`K1.14`

```
$ ls -al /mnt/s3fs/bdmixdata/
total 50331651
drwxr-xr-x 1 1000 1000           0 Nov 28 04:57 .
drwxrwxr-x 1 1000 1000           0 Jan  1  1970 ..
-rw-r--r-- 1 1000 1000           3 Nov 28 08:34 new.txt
-rw-r--r-- 1 1000 1000 17179869184 Nov 28 04:59 test02-016G
-rw-r--r-- 1 1000 1000 34359738368 Nov 28 05:03 test02-032G
$ 
```