### PR TITLE
Enable auto_cache option from pvc spec

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -93,6 +93,7 @@ type Options struct {
 	ServiceInstanceIDB64    string `json:"kubernetes.io/secret/service-instance-id,omitempty"`
 	CAbundleB64             string `json:"kubernetes.io/secret/ca-bundle-crt,omitempty"`
 	CosServiceIP            string `json:"service-ip,omitempty"`
+	AutoCache               bool   `json:"auto_cache,string,omitempty"`
 }
 
 // PathExists returns true if the specified path exists.
@@ -620,6 +621,10 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 
 	if options.CurlDebug {
 		args = append(args, "-o", "curldbg")
+	}
+
+	if options.AutoCache {
+		args = append(args, "-o", "auto_cache")
 	}
 
 	if options.KernelCache {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -48,6 +48,7 @@ const (
 	optionServiceInstanceID       = "kubernetes.io/secret/service-instance-id"
 	optionCAbundleB64             = "kubernetes.io/secret/ca-bundle-crt"
 	optionServiceIP               = "service-ip"
+	optionAutoCache               = "auto_cache"
 
 	testDir            = "/tmp/"
 	testChunkSizeMB    = 500
@@ -1118,6 +1119,38 @@ func Test_Mount_fsGroupNew_Nogroup_Positive(t *testing.T) {
 		"-o", "uid=65534",
 		"-o", "default_acl=private",
 	}
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
+		assert.Equal(t, expectedArgs, commandArgs)
+	}
+}
+
+func Test_AutoCache_Positive(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionAutoCache] = "true"
+
+	expectedArgs := []string{
+		testBucket,
+		testDir,
+		"-o", "multireq_max=" + strconv.Itoa(testMultiReqMax),
+		"-o", "cipher_suites=" + testTLSCipherSuite,
+		"-o", "use_path_request_style",
+		"-o", "passwd_file=" + path.Join(dataRootPath, fmt.Sprintf("%x", sha256.Sum256([]byte(testDir))), passwordFileName),
+		"-o", "url=" + testOSEndpoint,
+		"-o", "endpoint=" + testStorageClass,
+		"-o", "parallel_count=" + strconv.Itoa(testParallelCount),
+		"-o", "multipart_size=" + strconv.Itoa(testChunkSizeMB),
+		"-o", "dbglevel=" + testDebugLevel,
+		"-o", "max_stat_cache_size=" + strconv.Itoa(testStatCacheSize),
+		"-o", "allow_other",
+		"-o", "max_background=1000",
+		"-o", "mp_umask=002",
+		"-o", "instance_name=" + testDir,
+		"-o", "auto_cache",
+		"-o", "default_acl=private",
+	}
+
 	resp := p.Mount(r)
 	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
 		assert.Equal(t, expectedArgs, commandArgs)

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -77,7 +77,6 @@ type scOptions struct {
 	ConnectTimeoutSeconds   string `json:"ibm.io/connect-timeout,omitempty"`
 	ReadwriteTimeoutSeconds string `json:"ibm.io/readwrite-timeout,omitempty"`
 	UseXattr                bool   `json:"ibm.io/use-xattr,string"`
-	AutoCache               bool   `json:"ibm.io/auto_cache,string,omitempty"`
 }
 
 const (
@@ -405,7 +404,6 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 
 	if pvc.AutoCache {
 		sc.KernelCache = false
-		sc.AutoCache = pvc.AutoCache
 	}
 
 	driverOptions, err := parser.MarshalToMap(&driver.Options{
@@ -429,7 +427,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 		UseXattr:                sc.UseXattr,
 		AccessMode:              string(accessMode[0]),
 		CosServiceIP:            svcIp,
-		AutoCache:               sc.AutoCache,
+		AutoCache:               pvc.AutoCache,
 	})
 	if err != nil {
 		return nil, fmt.Errorf(pvcName+":"+clusterID+":cannot marshal driver options: %v", err)

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -89,6 +89,7 @@ const (
 	parameterIAMEndpoint            = "ibm.io/iam-endpoint"
 	parameterStorageClass           = "ibm.io/object-store-storage-class"
 	parameterStatCacheExpireSeconds = "ibm.io/stat-cache-expire-seconds"
+	parameterAutoCache              = "ibm.io/auto_cache"
 
 	optionChunkSizeMB             = "chunk-size-mb"
 	optionParallelCount           = "parallel-count"
@@ -111,6 +112,7 @@ const (
 	optionUseXattr                = "use-xattr"
 	optionAccessMode              = "access-mode"
 	optionServiceIP               = "service-ip"
+	optionAutoCache               = "auto_cache"
 )
 
 type clientGoConfig struct {
@@ -1050,4 +1052,14 @@ func Test_Delete_TLS_Positive(t *testing.T) {
 	writeFile = writeFileSuccess
 	err := p.Delete(pv)
 	assert.NoError(t, err)
+}
+
+func Test_Provision_AutoCache_Positive(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[parameterAutoCache] = "true"
+
+	pv, err := p.Provision(v)
+	assert.NoError(t, err)
+	assert.Equal(t, "true", pv.Spec.FlexVolume.Options[optionAutoCache])
 }


### PR DESCRIPTION
In PVC spec, user can add
`ibm.io/auto_cache: "true"`
to enable auto_cache mount option while mounting. This would disable `kernel_cache` if set to true from Storage Class.