### PR TITLE
Fix issue for re-using existing bucket with auto-create-bucket: true

### DIFF
--- a/utils/backend/fake/fake_backend.go
+++ b/utils/backend/fake/fake_backend.go
@@ -22,6 +22,8 @@ type ObjectStorageSessionFactory struct {
 	FailCheckBucketAccess bool
 	//FailCreateBucket ...
 	FailCreateBucket bool
+	//FailCreateBucket with specific error msg...
+	FailCreateBucketErrMsg string
 	//FailDeleteBucket ...
 	FailDeleteBucket bool
 	//CheckObjectPathExistenceError ...
@@ -87,7 +89,7 @@ func (s *fakeObjectStorageSession) CheckObjectPathExistence(bucket, objectpath s
 func (s *fakeObjectStorageSession) CreateBucket(bucket string) (string, error) {
 	s.factory.LastCreatedBucket = bucket
 	if s.factory.FailCreateBucket {
-		return "", errors.New("")
+		return "", errors.New(s.factory.FailCreateBucketErrMsg)
 	}
 	return "", nil
 }


### PR DESCRIPTION
**What this PR does / why we need it:**
Code change to fix the issue for re-using existing bucket with `auto-create-bucket: true`.

**Issue Description:** Currently if bucket is already created and if user tries to create a PVC with that bucket and `auto-create-bucket: true`, then PVC creation fails with below error:
`cannot create bucket mayank-test-06: BucketAlreadyExists: The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again.`

**Which issue(s) this PR fixes** (optional, in fixes #(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
None

**Special notes for your reviewer:**
Tested the code in IKS cluster.