### PR TITLE
Restrict the use of COS Secrets by namespace.

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -40,6 +40,8 @@ const (
 	SecretSecretKey = "secret-key"
 	// SecretAPIKey is the key name for the IBM API Key (IAM Authentication)
 	SecretAPIKey = "api-key"
+	//SecretAllowedNS is the key name for the Allowed Namespace
+	SecretAllowedNS = "allowed_ns"
 	// SecretServiceInstanceID is the key name for the service instance ID (IAM Authentication)
 	SecretServiceInstanceID = "service-instance-id"
 	// defaultIAMEndPoint is the default URL of the IBM IAM endpoint

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -375,7 +375,7 @@ func (p *IBMS3fsProvisioner) Provision(options controller.VolumeOptions) (*v1.Pe
 			}
 		}
 		if allowed == false {
-			return nil, errors.New(pvcName + ":" + clusterID + ":cannot create bucket as PVC creation in this namespace is not allowed")
+			return nil, errors.New(pvcName + ":" + clusterID + ":PVC creation in " + pvcNamespace + " namespace is not allowed")
 		}
 	}
 

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -130,7 +130,7 @@ type clientGoConfig struct {
 var (
 	writeFileError   = func(string, []byte, os.FileMode) error { return errors.New("") }
 	writeFileSuccess = func(string, []byte, os.FileMode) error { return nil }
-	testNamespace		 = "test-namespace"
+	testNamespace    = "test-namespace"
 )
 
 func getFakeClientGo(cfg *clientGoConfig) kubernetes.Interface {
@@ -615,7 +615,7 @@ func Test_Provision_PVCNamespaceNotAllowedInSecrets(t *testing.T) {
 
 	_, err := p.Provision(v)
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "PVC creation in " + v.PVC.Namespace  + " namespace is not allowed")
+		assert.Contains(t, err.Error(), "PVC creation in "+v.PVC.Namespace+" namespace is not allowed")
 	}
 }
 


### PR DESCRIPTION
The use of cos secrets is restricted by adding the allowed_namespace (allowed_ns) condition in the secret. Hence, PVC creation will be successful only if PVC namespace is in the list of allowed namespace.