### PR TITLE
Fix vet error for downstream code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,9 @@ require (
 	github.com/IBM/go-sdk-core/v3 v3.3.1
 	github.com/IBM/ibm-cos-sdk-go v1.7.0
 	github.com/IBM/ibm-cos-sdk-go-config v1.2.0
-	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/golang/protobuf v1.5.2
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/miekg/dns v1.1.43 // indirect
-	github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.7.0
@@ -23,7 +21,7 @@ require (
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
 	sigs.k8s.io/sig-storage-lib-external-provisioner v4.1.0+incompatible
-	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0 // indirect
+	sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.3.0
 )
 
 replace sigs.k8s.io/sig-storage-lib-external-provisioner v4.1.0+incompatible => sigs.k8s.io/sig-storage-lib-external-provisioner/v6 v6.0.0

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,6 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -293,8 +291,6 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0 h1:i5VIxp6QB8oWZ8IkK8zrDgeT6ORGIUeiN+61iETwJbI=
-github.com/pierrre/gotestcover v0.0.0-20160517101806-924dca7d15f0/go.mod h1:4xpMLz7RBWyB+ElzHu8Llua96TRCB3YwX+l5EP1wmHk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -30,7 +30,7 @@ import (
 	"net"
 	"os"
 	"path"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
 	"strconv"
 	"strings"
 	"time"

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	k8fake "k8s.io/client-go/kubernetes/fake"
 	"os"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
 	//"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/api/core/v1"
 	//"k8s.io/client-go/pkg/runtime"


### PR DESCRIPTION
In downstream pipeline , we see below error

```# Checking packages...
go vet github.com/IBM/ibmcloud-object-storage-plugin/driver github.com/IBM/ibmcloud-object-storage-plugin/driver/interfaces github.com/IBM/ibmcloud-object-storage-plugin/ibm-provider/provider github.com/IBM/ibmcloud-object-storage-plugin/ibm-provider/provider/fake-provider github.com/IBM/ibmcloud-object-storage-plugin/provisioner github.com/IBM/ibmcloud-object-storage-plugin/utils/backend github.com/IBM/ibmcloud-object-storage-plugin/utils/backend/fake github.com/IBM/ibmcloud-object-storage-plugin/utils/config github.com/IBM/ibmcloud-object-storage-plugin/utils/consts github.com/IBM/ibmcloud-object-storage-plugin/utils/grpc-client github.com/IBM/ibmcloud-object-storage-plugin/utils/grpc-client/fake-grpc github.com/IBM/ibmcloud-object-storage-plugin/utils/logger github.com/IBM/ibmcloud-object-storage-plugin/utils/parser github.com/IBM/ibmcloud-object-storage-plugin/utils/uuid
../../../github.com/IBM/ibmcloud-object-storage-plugin/provisioner/ibm-s3fs-provisioner.go:33:2: code in directory /root/WORKSPACE/src/github.com/IBM/ibmcloud-object-storage-plugin/vendor/sigs.k8s.io/sig-storage-lib-external-pro
visioner/controller expects import "sigs.k8s.io/sig-storage-lib-external-provisioner/v6/controller"
```

This PR is to fix this error