### PR TITLE
update curldbg to support body option and support additional mount options as annotation from pvc spec

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -96,6 +96,7 @@ type Options struct {
 	CAbundleB64             string `json:"kubernetes.io/secret/ca-bundle-crt,omitempty"`
 	CosServiceIP            string `json:"service-ip,omitempty"`
 	AutoCache               bool   `json:"auto_cache,string,omitempty"`
+	AddMountParam           string `json:"add-mount-param,omitempty"`
 }
 
 // PathExists returns true if the specified path exists.
@@ -654,6 +655,10 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 
 	if options.UseXattr {
 		args = append(args, "-o", "use_xattr")
+	}
+
+	if options.AddMountParam != "" {
+		args = append(args, options.AddMountParam)
 	}
 
 	fInfo, err = os.Lstat(mountRequest.MountDir)

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -626,7 +626,7 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 	}
 
 	if options.CurlDebug {
-		args = append(args, "-o", "curldbg")
+		args = append(args, "-o", "curldbg=body")
 	}
 
 	if options.AutoCache {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -550,7 +550,7 @@ func Test_CurlDebug_Positive(t *testing.T) {
 		"-o", "mp_umask=002",
 		"-o", "instance_name=" + testDir,
 		"-o", "cipher_suites=" + testTLSCipherSuite,
-		"-o", "curldbg",
+		"-o", "curldbg=body",
 		"-o", "default_acl=private",
 	}
 

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -49,6 +49,7 @@ const (
 	optionCAbundleB64             = "kubernetes.io/secret/ca-bundle-crt"
 	optionServiceIP               = "service-ip"
 	optionAutoCache               = "auto_cache"
+	optionAddMountParam           = "add-mount-param"
 
 	testDir            = "/tmp/"
 	testChunkSizeMB    = 500
@@ -67,6 +68,7 @@ const (
 	testDebugLevel     = "debug"
 	testCABundle       = "test-ca-bundle"
 	testServiceIP      = "1.0.0.0.1"
+	testAddMountParam  = "-o opt1 -o opt2"
 )
 
 // these are actually constants
@@ -1147,6 +1149,38 @@ func Test_AutoCache_Positive(t *testing.T) {
 		"-o", "cipher_suites=" + testTLSCipherSuite,
 		"-o", "auto_cache",
 		"-o", "default_acl=private",
+	}
+
+	resp := p.Mount(r)
+	if assert.Equal(t, interfaces.StatusSuccess, resp.Status) {
+		assert.Equal(t, expectedArgs, commandArgs)
+	}
+}
+
+func Test_AddMountParam(t *testing.T) {
+	p := getPlugin()
+	r := getMountRequest()
+	r.Opts[optionAddMountParam] = testAddMountParam
+
+	expectedArgs := []string{
+		testBucket,
+		testDir,
+		"-o", "multireq_max=" + strconv.Itoa(testMultiReqMax),
+		"-o", "use_path_request_style",
+		"-o", "passwd_file=" + path.Join(dataRootPath, fmt.Sprintf("%x", sha256.Sum256([]byte(testDir))), passwordFileName),
+		"-o", "url=" + testOSEndpoint,
+		"-o", "endpoint=" + testStorageClass,
+		"-o", "parallel_count=" + strconv.Itoa(testParallelCount),
+		"-o", "multipart_size=" + strconv.Itoa(testChunkSizeMB),
+		"-o", "dbglevel=" + testDebugLevel,
+		"-o", "max_stat_cache_size=" + strconv.Itoa(testStatCacheSize),
+		"-o", "allow_other",
+		"-o", "max_background=1000",
+		"-o", "mp_umask=002",
+		"-o", "instance_name=" + testDir,
+		"-o", "cipher_suites=" + testTLSCipherSuite,
+		"-o", "default_acl=private",
+		"-o opt1 -o opt2",
 	}
 
 	resp := p.Mount(r)

--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -64,6 +64,7 @@ type pvcAnnotations struct {
 	CosServiceNamespace     string `json:"ibm.io/cos-service-ns,omitempty"`
 	AutoCache               bool   `json:"ibm.io/auto_cache,string,omitempty"`
 	SetAccessPolicy         string `json:"ibm.io/set-access-policy,omitempty"`
+	AddMountParam           string `json:"ibm.io/add-mount-param"`
 }
 
 // Storage Class options
@@ -90,6 +91,7 @@ type scOptions struct {
 	ConnectTimeoutSeconds   string `json:"ibm.io/connect-timeout,omitempty"`
 	ReadwriteTimeoutSeconds string `json:"ibm.io/readwrite-timeout,omitempty"`
 	UseXattr                bool   `json:"ibm.io/use-xattr,string"`
+	AddMountParam           string `json:"ibm.io/add-mount-param"`
 }
 
 const (
@@ -397,6 +399,11 @@ func (p *IBMS3fsProvisioner) validateAnnotations(ctx context.Context, options co
 		return pvc, sc, svcIp, fmt.Errorf(pvcName+":"+clusterID+":object-path cannot be set when auto-create is enabled, got: %s", pvc.ObjectPath)
 	}
 
+	// Additional parameter should be of form "-o opt1 -o opt2=xxx -o opt3"
+	if pvc.AddMountParam != "" {
+		sc.AddMountParam = pvc.AddMountParam
+	}
+
 	return pvc, sc, svcIp, nil
 }
 
@@ -660,6 +667,7 @@ func (p *IBMS3fsProvisioner) Provision(ctx context.Context, options controller.P
 		AccessMode:              string(accessMode[0]),
 		CosServiceIP:            svcIp,
 		AutoCache:               pvc.AutoCache,
+		AddMountParam:           sc.AddMountParam,
 	})
 	if err != nil {
 		return nil, controller.ProvisioningFinished, fmt.Errorf(pvcName+":"+clusterID+":cannot marshal driver options: %v", err)
@@ -689,6 +697,7 @@ func (p *IBMS3fsProvisioner) Provision(ctx context.Context, options controller.P
 		DebugLevel:              pvc.DebugLevel,
 		CosServiceName:          pvc.CosServiceName,
 		SetAccessPolicy:         pvc.SetAccessPolicy,
+		AddMountParam:           pvc.AddMountParam,
 	})
 
 	if err != nil {

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -66,6 +66,7 @@ const (
 	testStorageClass           = "test-storage-class"
 	testObjectPath             = "/test/object-path"
 	testValidateBucket         = "yes"
+	testAddMountParam          = "-o op1 -o op2"
 
 	annotationBucket                  = "ibm.io/bucket"
 	annotationObjectPath              = "ibm.io/object-path"
@@ -83,6 +84,7 @@ const (
 	annotationServiceName             = "ibm.io/cos-service"
 	annotationServiceNamespace        = "ibm.io/cos-service-ns"
 	annotationSetAccessPolicy         = "ibm.io/set-access-policy"
+	annotationAddMountParam           = "ibm.io/add-mount-param"
 
 	parameterChunkSizeMB            = "ibm.io/chunk-size-mb"
 	parameterParallelCount          = "ibm.io/parallel-count"
@@ -121,6 +123,7 @@ const (
 	optionAccessMode              = "access-mode"
 	optionServiceIP               = "service-ip"
 	optionAutoCache               = "auto_cache"
+	optionAddMountParam           = "add-mount-param"
 )
 
 type clientGoConfig struct {
@@ -1515,4 +1518,14 @@ func Test_Provision_AutoCache_Positive(t *testing.T) {
 	pv, _, err := p.Provision(context.Background(), v)
 	assert.NoError(t, err)
 	assert.Equal(t, "true", pv.Spec.FlexVolume.Options[optionAutoCache])
+}
+
+func Test_Provision_PVCAnnotations_AddMountParam(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.PVC.Annotations[annotationAddMountParam] = testAddMountParam
+
+	pv, _, err := p.Provision(context.Background(), v)
+	assert.NoError(t, err)
+	assert.Equal(t, testAddMountParam, pv.Spec.FlexVolume.Options[optionAddMountParam])
 }


### PR DESCRIPTION
1. update curldbg to support body option
Refer: https://github.com/s3fs-fuse/s3fs-fuse/pull/1295

**Approach:**

We will set "body" option as parameter when curldbg is set to true from PVC


**Details**
```
Added a parameter to output body to curldbg option.

The curldbg option can be specified by curldbg=normal, curldbg=body or the same curldbg as before.
If the parameter is omitted, it is the same as normal.

curldbg or curldbg=normal is the same debug output as before.
When curldbg=body is specified, in addition to this debug output, the request body of CompleteMultipartUpload and the response body of ListObjects are output.

In this PR, output body is limited to a specific API.
In the future, if necessary, we will add APIs or change the APIs to output body output.
```

2.  support additional mount options as annotation from pvc spec
```
In PVC Spec user can add more mount options as below.
`ibm.io/add-mount-param: "-o opt1 -o opt2"`
These user provided parameters are not validated from code and are passed as a string to s3fs command
```


