### PR TITLE
Fix bug in passing additional mount options

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -658,7 +658,10 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 	}
 
 	if options.AddMountParam != "" {
-		args = append(args, options.AddMountParam)
+		paramSlice := strings.Split(options.AddMountParam, ",")
+		for _, value := range paramSlice {
+			args = append(args, "-o", value)
+		}
 	}
 
 	fInfo, err = os.Lstat(mountRequest.MountDir)

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -68,7 +68,7 @@ const (
 	testDebugLevel     = "debug"
 	testCABundle       = "test-ca-bundle"
 	testServiceIP      = "1.0.0.0.1"
-	testAddMountParam  = "-o opt1 -o opt2"
+	testAddMountParam  = "opt1,opt2"
 )
 
 // these are actually constants
@@ -1180,7 +1180,8 @@ func Test_AddMountParam(t *testing.T) {
 		"-o", "instance_name=" + testDir,
 		"-o", "cipher_suites=" + testTLSCipherSuite,
 		"-o", "default_acl=private",
-		"-o opt1 -o opt2",
+		"-o", "opt1",
+		"-o", "opt2",
 	}
 
 	resp := p.Mount(r)

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -66,7 +66,7 @@ const (
 	testStorageClass           = "test-storage-class"
 	testObjectPath             = "/test/object-path"
 	testValidateBucket         = "yes"
-	testAddMountParam          = "-o op1 -o op2"
+	testAddMountParam          = "op1,op2"
 
 	annotationBucket                  = "ibm.io/bucket"
 	annotationObjectPath              = "ibm.io/object-path"


### PR DESCRIPTION
As per PR: https://github.com/IBM/ibmcloud-object-storage-plugin/pull/103
mount options in PVC spec was specified as
``ibm.io/add-mount-param: "-o opt1 -o opt2"``

Above way of passing causes issues while mounting 

```
{"level":"info","ts":"2022-03-14T07:40:58.682-0500","msg":"d9c27b0f-5d7a-45e0-8c99-376623665827:MountCommand End","response":{"status":"Failure","message":"Error mounting volume: s3fs mount failed: fuse: unknown option ` enable_noobj_cache'\n","capabilities":{"attach":false,"fsGroup":false}}}
{"level":"info","ts":"2022-03-14T07:40:58.682-0500","msg":":FlexVolumeResponse","output":"{\"status\":\"Failure\",\"message\":\"Error mounting volume: s3fs mount failed: fuse: unknown option ` enable_noobj_cache'\\n\",\"capabilities\":{\"attach\":false,\"fsGroup\":false}}"}
```

Change in syntax of how additional options can be specified

```
ibm.io/add-mount-param: "opt1,opt2"
```
Ex:

```
ibm.io/add-mount-param: "del_cache,retries=6"
```

Logs

```
{"level":"info","ts":"2022-03-14T08:40:38.574-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:Target directory before-mount: ","mode:":"drwxr-x---","uid:":0,"gid:":0,"path:":"/var/data/kubelet/pods/1181a87c-deb9-474e-a3a3-5c83720e4aec/volumes/ibm~ibmc-s3fs/pvc-1e925f1f-058c-440a-9b46-fdff7f21c66b"}
{"level":"info","ts":"2022-03-14T08:40:38.574-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:Running s3fs","args":["mount-bkt","/var/data/kubelet/pods/1181a87c-deb9-474e-a3a3-5c83720e4aec/volumes/ibm~ibmc-s3fs/pvc-1e925f1f-058c-440a-9b46-fdff7f21c66b","-o","multireq_max=20","-o","use_path_request_style","-o","passwd_file=/var/lib/ibmc-s3fs/039a89ac8148c0e102b2b983f6b044c2e8c42a029112fc99c3df1dfb38e76b3b/passwd","-o","url=https://s3.direct.us-south.cloud-object-storage.appdomain.cloud","-o","endpoint=us-south-cold","-o","parallel_count=2","-o","multipart_size=16","-o","dbglevel=warn","-o","max_stat_cache_size=100000","-o","allow_other","-o","max_background=1000","-o","mp_umask=002","-o","instance_name=/var/data/kubelet/pods/1181a87c-deb9-474e-a3a3-5c83720e4aec/volumes/ibm~ibmc-s3fs/pvc-1e925f1f-058c-440a-9b46-fdff7f21c66b","-o","retries=5","-o","auto_cache","-o","default_acl=private","-o","del_cache","-o","retries=6"]}
{"level":"info","ts":"2022-03-14T08:40:38.583-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:S3FS-Fuse info:","Version":"Amazon Simple Storage Service File System V1.90 (commit:cd466eb) with OpenSSL"}
{"level":"info","ts":"2022-03-14T08:40:38.583-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:S3FS-Driver info:","Version":"9e6cd7c313e13bf5595a248fddcc02f532d688e1"}
{"level":"info","ts":"2022-03-14T08:40:38.808-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:Target directory after-mount: ","mode:":"drwxrwxr-x","uid:":0,"gid:":0,"path:":"/var/data/kubelet/pods/1181a87c-deb9-474e-a3a3-5c83720e4aec/volumes/ibm~ibmc-s3fs/pvc-1e925f1f-058c-440a-9b46-fdff7f21c66b"}
{"level":"info","ts":"2022-03-14T08:40:38.809-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:Successfully executed mount","mountRequest.MountDir":"/var/data/kubelet/pods/1181a87c-deb9-474e-a3a3-5c83720e4aec/volumes/ibm~ibmc-s3fs/pvc-1e925f1f-058c-440a-9b46-fdff7f21c66b"}
{"level":"info","ts":"2022-03-14T08:40:38.809-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:S3fsPlugin-Mount()-end"}
{"level":"info","ts":"2022-03-14T08:40:38.809-0500","msg":"1181a87c-deb9-474e-a3a3-5c83720e4aec:MountCommand End","response":{"status":"Success","message":"Volume mounted successfully to /var/data/kubelet/pods/1181a87c-deb9-474e-a3a3-5c83720e4aec/volumes/ibm~ibmc-s3fs/pvc-1e925f1f-058c-440a-9b46-fdff7f21c66b","capabilities":{"attach":false,"fsGroup":false}}}
{"level":"info","ts":"2022-03-14T08:40:38.809-0500","msg":":FlexVolumeResponse","output":"{\"status\":\"Success\",\"message\":\"Volume mounted successfully to /var/data/kubelet/pods/1181a87c-deb9-474e-a3a3-5c83720e4aec/volumes/ibm~ibmc-s3fs/pvc-1e925f1f-058c-440a-9b46-fdff7f21c66b\",\"capabilities\":{\"attach\":false,\"fsGroup\":false}}"}


```