### PR TITLE
handle mount err

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -696,7 +696,12 @@ func (p *S3fsPlugin) mountInternal(mountRequest interfaces.FlexVolumeMountReques
 	}
 
 	fInfo, err = os.Lstat(mountRequest.MountDir)
-	if err == nil {
+	if err != nil {
+		p.Logger.Error(podUID+"Check mountpoint failed",
+			zap.String("Path", mountRequest.MountDir),
+		)
+		return fmt.Errorf("s3fs mount failed, mount command:`s3fs %s`", strings.Join(args, " "))
+	} else {
 		p.Logger.Info(podUID+":"+"Target directory after-mount: ",
 			zap.String("mode:", fInfo.Mode().String()),
 			zap.Uint32("uid:", fInfo.Sys().(*syscall.Stat_t).Uid),


### PR DESCRIPTION
If the s3fs mount command fails, the process will exit without error. 
you can find mount directory in k8s pod, but no files.

It should be return err if mountpoint does not exists, and pod does not need create.