### PR TITLE
fix: fix debug-level propogation

### DIFF
--- a/provisioner/ibm-s3fs-provisioner.go
+++ b/provisioner/ibm-s3fs-provisioner.go
@@ -754,9 +754,13 @@ func (p *IBMS3fsProvisioner) Provision(ctx context.Context, options controller.P
 		sc.UseXattr = pvc.UseXattr
 	}
 
-	if pvc.DebugLevel != "" {
+	if pvc.DebugLevel != nil && pvc.DebugLevel != "" {
 		sc.DebugLevel = pvc.DebugLevel
 	}
+    if sc.DebugLevel == "" {
+        // Give a default of 'warn' vs. making s3fs-fuse error out with dbglevel=""
+        sc.DebugLevel = "warn"
+    }
 
 	if pvc.CurlDebug {
 		sc.CurlDebug = pvc.CurlDebug

--- a/provisioner/ibm-s3fs-provisioner_test.go
+++ b/provisioner/ibm-s3fs-provisioner_test.go
@@ -1538,6 +1538,15 @@ func Test_Provision_PVCAnnotations_DebugLevel(t *testing.T) {
 	assert.Equal(t, "info", pv.Spec.FlexVolume.Options[optionDebugLevel])
 }
 
+func Test_Provision_PVCAnnotations_Preserve_SC_DebugLevel(t *testing.T) {
+	p := getProvisioner()
+	v := getVolumeOptions()
+	v.StorageClass.Parameters["ibm.io/debug-level"] = "info"
+	pv, _, err := p.Provision(context.Background(), v)
+	assert.NoError(t, err)
+	assert.Equal(t, "info", pv.Spec.FlexVolume.Options[optionDebugLevel])
+}
+
 func Test_Provision_PVCAnnotations_CurlDebug(t *testing.T) {
 	p := getProvisioner()
 	v := getVolumeOptions()


### PR DESCRIPTION
resolves: #200 

Fix issue where unset PVC's ibm.io/debug-level was overriding storage class value of it when creating the PV.  Adding default value so we don't error out if it is not set in either StorageClass or PVC (usability).